### PR TITLE
docs: update README to turn off Supabase email confirmation for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A comprehensive real-time judging system for hackathons and competitive events. 
    - Go to [app.supabase.com](https://app.supabase.com)
    - Click "New Project" and wait ~2 minutes for setup
    - **Configure Authentication Settings**:
-     - Go to Authentication → Settings → User Signups
+     - Go to Authentication → Configuration → Sign In / Providers
      - Turn OFF "Confirm email" (required for development)
    - Go to Settings → API and copy your credentials
 


### PR DESCRIPTION
During project setup, the Authentication settings tab described in the README (“Authentication → Settings → User Signups”) was not visible/found. The relevant options are located under Authentication → Configuration → Sign In / Providers.

<img width="1618" height="777" alt="Screenshot 2025-09-02 at 4 01 26 AM" src="https://github.com/user-attachments/assets/ede062c4-c9e8-497c-a978-67b2a8025269" />

The README has been updated to reflect this. It is unclear whether this differs from the previous instructions, so verification is recommended.