### PR TITLE
IC-11 feat: implement LearnWorlds ingestion client  #80 #81

### DIFF
--- a/app/api/admin/learnworlds/ingest/route.ts
+++ b/app/api/admin/learnworlds/ingest/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserFromSession } from '@/lib/auth/server';
+import {
+  LearnworldsAuthError,
+  LearnworldsConfigError,
+  LearnworldsFetchError,
+} from '@/lib/learnworlds/client';
+import { runLearnworldsIngestion } from '@/lib/learnworlds/ingestion';
+import type { LearnworldsTriggerMode } from '@/lib/learnworlds/types';
+
+interface IngestionRequestBody {
+  triggerMode?: LearnworldsTriggerMode;
+}
+
+const ALLOWED_TRIGGER_MODES: LearnworldsTriggerMode[] = ['manual', 'scheduled', 'webhook'];
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getUserFromSession();
+
+    if (!user || user.role !== 'admin') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as IngestionRequestBody;
+    const triggerMode = body.triggerMode ?? 'manual';
+
+    if (!ALLOWED_TRIGGER_MODES.includes(triggerMode)) {
+      return NextResponse.json({ error: 'Invalid triggerMode value' }, { status: 400 });
+    }
+
+    const result = await runLearnworldsIngestion(triggerMode);
+
+    return NextResponse.json({
+      status: 'ok',
+      syncRunId: result.syncRunId,
+      totalRecords: result.totalRecords,
+      validRecords: result.validRecords,
+      invalidRecords: result.invalidRecords,
+    });
+  } catch (error) {
+    if (error instanceof LearnworldsConfigError) {
+      console.error('LearnWorlds configuration error:', error.message);
+      return NextResponse.json(
+        { error: 'LearnWorlds integration is not configured correctly' },
+        { status: 500 }
+      );
+    }
+
+    if (error instanceof LearnworldsAuthError) {
+      console.error('LearnWorlds authentication failure');
+      return NextResponse.json(
+        { error: 'Failed to authenticate with LearnWorlds' },
+        { status: 502 }
+      );
+    }
+
+    if (error instanceof LearnworldsFetchError) {
+      console.error('LearnWorlds fetch failure:', error.message);
+      return NextResponse.json({ error: 'Failed to fetch LearnWorlds data' }, { status: 502 });
+    }
+
+    console.error('Unexpected LearnWorlds ingestion error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/lib/learnworlds/client.ts
+++ b/lib/learnworlds/client.ts
@@ -1,0 +1,260 @@
+import { LearnworldsFetchResponse, LearnworldsProgressRecord } from './types';
+
+interface LearnworldsClientConfig {
+  tokenUrl: string;
+  apiBaseUrl: string;
+  progressEndpoint: string;
+  clientId: string;
+  clientSecret: string;
+  clientHeaderValue: string;
+  timeoutMs: number;
+}
+
+interface OAuthTokenResponse {
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number;
+}
+
+export class LearnworldsConfigError extends Error {
+  code = 'LEARNWORLDS_CONFIG_ERROR';
+}
+
+export class LearnworldsAuthError extends Error {
+  code = 'LEARNWORLDS_AUTH_FAILED';
+}
+
+export class LearnworldsFetchError extends Error {
+  code = 'LEARNWORLDS_FETCH_FAILED';
+}
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new LearnworldsConfigError(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function getClientConfig(): LearnworldsClientConfig {
+  const tokenUrl = getRequiredEnv('LEARNWORLDS_TOKEN_URL');
+  const apiBaseUrl = getRequiredEnv('LEARNWORLDS_API_BASE_URL');
+  const progressEndpoint = process.env.LEARNWORLDS_PROGRESS_ENDPOINT?.trim() || '/progress';
+  const clientId = getRequiredEnv('LEARNWORLDS_CLIENT_ID');
+  const clientSecret = getRequiredEnv('LEARNWORLDS_CLIENT_SECRET');
+  const clientHeaderValue = getRequiredEnv('LEARNWORLDS_CLIENT_HEADER_VALUE');
+  const timeoutMs = Number.parseInt(process.env.LEARNWORLDS_TIMEOUT_MS || '15000', 10);
+
+  if (!tokenUrl.startsWith('https://') || !apiBaseUrl.startsWith('https://')) {
+    throw new LearnworldsConfigError('LearnWorlds URLs must use HTTPS');
+  }
+
+  return {
+    tokenUrl,
+    apiBaseUrl: apiBaseUrl.replace(/\/$/, ''),
+    progressEndpoint: progressEndpoint.startsWith('/') ? progressEndpoint : `/${progressEndpoint}`,
+    clientId,
+    clientSecret,
+    clientHeaderValue,
+    timeoutMs: Number.isNaN(timeoutMs) ? 15000 : timeoutMs,
+  };
+}
+
+function readStringValue(input: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+    if (typeof value === 'number') {
+      return String(value);
+    }
+  }
+  return null;
+}
+
+function readNumberValue(input: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number.parseFloat(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return null;
+}
+
+function normalizeProgressRecord(raw: Record<string, unknown>): LearnworldsProgressRecord | null {
+  const learnerId = readStringValue(raw, ['learner_id', 'learnerId', 'user_id', 'userId']);
+  const courseId = readStringValue(raw, ['course_id', 'courseId', 'product_id', 'productId']);
+
+  if (!learnerId || !courseId) {
+    return null;
+  }
+
+  return {
+    learnerId,
+    courseId,
+    moduleId: readStringValue(raw, ['module_id', 'moduleId']),
+    lessonId: readStringValue(raw, ['lesson_id', 'lessonId', 'activity_id', 'activityId']),
+    completionStatus: readStringValue(raw, ['completion_status', 'completionStatus', 'status']),
+    progressPercentage: readNumberValue(raw, [
+      'progress_percentage',
+      'progressPercentage',
+      'progress',
+    ]),
+    lastActivityTimestamp: readStringValue(raw, [
+      'last_activity_timestamp',
+      'lastActivityTimestamp',
+      'last_activity_at',
+      'updated_at',
+    ]),
+    raw,
+  };
+}
+
+function parseResponsePayload(payload: unknown): Record<string, unknown>[] {
+  if (Array.isArray(payload)) {
+    return payload.filter((item): item is Record<string, unknown> => {
+      return Boolean(item) && typeof item === 'object' && !Array.isArray(item);
+    });
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const container = payload as Record<string, unknown>;
+  const candidateKeys = ['data', 'results', 'items', 'progress', 'activities'];
+
+  for (const key of candidateKeys) {
+    const value = container[key];
+    if (Array.isArray(value)) {
+      return value.filter((item): item is Record<string, unknown> => {
+        return Boolean(item) && typeof item === 'object' && !Array.isArray(item);
+      });
+    }
+  }
+
+  return [];
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getAccessToken(config: LearnworldsClientConfig): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+  });
+
+  const response = await fetchWithTimeout(
+    config.tokenUrl,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+      cache: 'no-store',
+    },
+    config.timeoutMs
+  );
+
+  if (!response.ok) {
+    throw new LearnworldsAuthError(`Token request failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as OAuthTokenResponse;
+  if (!payload.access_token) {
+    throw new LearnworldsAuthError('Token response did not include access_token');
+  }
+
+  return payload.access_token;
+}
+
+async function fetchWithRetries(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  maxRetries = 2
+): Promise<Response> {
+  let attempt = 0;
+
+  while (attempt <= maxRetries) {
+    const response = await fetchWithTimeout(url, init, timeoutMs);
+
+    if (response.status !== 429 && response.status < 500) {
+      return response;
+    }
+
+    if (attempt === maxRetries) {
+      return response;
+    }
+
+    const retryDelayMs = 500 * Math.pow(2, attempt);
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    attempt += 1;
+  }
+
+  throw new LearnworldsFetchError('Unexpected retry flow for LearnWorlds request');
+}
+
+export async function fetchLearnworldsProgressData(): Promise<LearnworldsFetchResponse> {
+  const config = getClientConfig();
+  const token = await getAccessToken(config);
+
+  const endpoint = `${config.apiBaseUrl}${config.progressEndpoint}`;
+  const response = await fetchWithRetries(
+    endpoint,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Lw-Client': config.clientHeaderValue,
+        Accept: 'application/json',
+      },
+      cache: 'no-store',
+    },
+    config.timeoutMs
+  );
+
+  if (!response.ok) {
+    throw new LearnworldsFetchError(
+      `LearnWorlds progress fetch failed with status ${response.status}`
+    );
+  }
+
+  const rawPayload = await response.json();
+  const rawRecords = parseResponsePayload(rawPayload);
+  const records = rawRecords
+    .map(normalizeProgressRecord)
+    .filter((record): record is LearnworldsProgressRecord => record !== null);
+
+  return {
+    records,
+    endpoint: config.progressEndpoint,
+    httpStatus: response.status,
+  };
+}

--- a/lib/learnworlds/client.ts
+++ b/lib/learnworlds/client.ts
@@ -8,6 +8,8 @@ interface LearnworldsClientConfig {
   clientSecret: string;
   clientHeaderValue: string;
   timeoutMs: number;
+  pageSize: number;
+  maxPages: number;
 }
 
 interface OAuthTokenResponse {
@@ -44,6 +46,8 @@ function getClientConfig(): LearnworldsClientConfig {
   const clientSecret = getRequiredEnv('LEARNWORLDS_CLIENT_SECRET');
   const clientHeaderValue = getRequiredEnv('LEARNWORLDS_CLIENT_HEADER_VALUE');
   const timeoutMs = Number.parseInt(process.env.LEARNWORLDS_TIMEOUT_MS || '15000', 10);
+  const pageSize = Number.parseInt(process.env.LEARNWORLDS_PAGE_SIZE || '100', 10);
+  const maxPages = Number.parseInt(process.env.LEARNWORLDS_MAX_PAGES || '100', 10);
 
   if (!tokenUrl.startsWith('https://') || !apiBaseUrl.startsWith('https://')) {
     throw new LearnworldsConfigError('LearnWorlds URLs must use HTTPS');
@@ -57,7 +61,16 @@ function getClientConfig(): LearnworldsClientConfig {
     clientSecret,
     clientHeaderValue,
     timeoutMs: Number.isNaN(timeoutMs) ? 15000 : timeoutMs,
+    pageSize: Number.isNaN(pageSize) ? 100 : pageSize,
+    maxPages: Number.isNaN(maxPages) ? 100 : maxPages,
   };
+}
+
+function buildPaginatedEndpoint(endpoint: string, page: number, pageSize: number): string {
+  const url = new URL(endpoint);
+  url.searchParams.set('page', String(page));
+  url.searchParams.set('per_page', String(pageSize));
+  return url.toString();
 }
 
 function readStringValue(input: Record<string, unknown>, keys: string[]): string | null {
@@ -226,35 +239,59 @@ export async function fetchLearnworldsProgressData(): Promise<LearnworldsFetchRe
   const token = await getAccessToken(config);
 
   const endpoint = `${config.apiBaseUrl}${config.progressEndpoint}`;
-  const response = await fetchWithRetries(
-    endpoint,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Lw-Client': config.clientHeaderValue,
-        Accept: 'application/json',
-      },
-      cache: 'no-store',
-    },
-    config.timeoutMs
-  );
+  const allRawRecords: Record<string, unknown>[] = [];
+  let firstPageStatus = 200;
 
-  if (!response.ok) {
-    throw new LearnworldsFetchError(
-      `LearnWorlds progress fetch failed with status ${response.status}`
+  for (let page = 1; page <= config.maxPages; page += 1) {
+    const paginatedEndpoint = buildPaginatedEndpoint(endpoint, page, config.pageSize);
+
+    const response = await fetchWithRetries(
+      paginatedEndpoint,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Lw-Client': config.clientHeaderValue,
+          Accept: 'application/json',
+        },
+        cache: 'no-store',
+      },
+      config.timeoutMs
     );
+
+    if (!response.ok) {
+      throw new LearnworldsFetchError(
+        `LearnWorlds progress fetch failed with status ${response.status} on page ${page}`
+      );
+    }
+
+    if (page === 1) {
+      firstPageStatus = response.status;
+    }
+
+    const rawPayload = await response.json();
+    const pageRecords = parseResponsePayload(rawPayload);
+    allRawRecords.push(...pageRecords);
+
+    if (pageRecords.length < config.pageSize) {
+      break;
+    }
+
+    if (page === config.maxPages) {
+      throw new LearnworldsFetchError(
+        `Reached LearnWorlds pagination limit at ${config.maxPages} pages`
+      );
+    }
   }
 
-  const rawPayload = await response.json();
-  const rawRecords = parseResponsePayload(rawPayload);
-  const records = rawRecords
+  const records = allRawRecords
     .map(normalizeProgressRecord)
     .filter((record): record is LearnworldsProgressRecord => record !== null);
 
   return {
     records,
+    rawCount: allRawRecords.length,
     endpoint: config.progressEndpoint,
-    httpStatus: response.status,
+    httpStatus: firstPageStatus,
   };
 }

--- a/lib/learnworlds/ingestion.ts
+++ b/lib/learnworlds/ingestion.ts
@@ -43,6 +43,69 @@ function hashRecord(record: LearnworldsProgressRecord): string {
   return createHash('sha256').update(JSON.stringify(record.raw)).digest('hex');
 }
 
+interface LearnworldsFailureNotificationPayload {
+  syncRunId: string;
+  triggerMode: LearnworldsTriggerMode;
+  errorMessage: string;
+}
+
+function getFailureWebhookUrl(): string | null {
+  const value = process.env.LEARNWORLDS_FAILURE_WEBHOOK_URL?.trim();
+  if (!value) {
+    return null;
+  }
+
+  if (!value.startsWith('https://')) {
+    console.warn('LEARNWORLDS_FAILURE_WEBHOOK_URL must use HTTPS; skipping notification');
+    return null;
+  }
+
+  return value;
+}
+
+async function notifyFailedIngestion(
+  payload: LearnworldsFailureNotificationPayload
+): Promise<void> {
+  const webhookUrl = getFailureWebhookUrl();
+  if (!webhookUrl) {
+    return;
+  }
+
+  const timeoutMs = Number.parseInt(
+    process.env.LEARNWORLDS_FAILURE_NOTIFY_TIMEOUT_MS || '5000',
+    10
+  );
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), Number.isNaN(timeoutMs) ? 5000 : timeoutMs);
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        event: 'learnworlds.ingestion.failed',
+        syncRunId: payload.syncRunId,
+        triggerMode: payload.triggerMode,
+        errorMessage: payload.errorMessage,
+        occurredAt: new Date().toISOString(),
+        environment: process.env.NODE_ENV || 'unknown',
+      }),
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      console.error(`LearnWorlds failure notification webhook returned status ${response.status}`);
+    }
+  } catch (notifyError) {
+    console.error('LearnWorlds failure notification failed:', notifyError);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export async function runLearnworldsIngestion(
   triggerMode: LearnworldsTriggerMode = 'manual'
 ): Promise<LearnworldsIngestionResult> {
@@ -118,6 +181,12 @@ export async function runLearnworldsIngestion(
         finishedAt: new Date().toISOString(),
       })
       .where(eq(learnworldsSyncRuns.id, syncRun.id));
+
+    await notifyFailedIngestion({
+      syncRunId: syncRun.id,
+      triggerMode,
+      errorMessage: safeErrorMessage,
+    });
 
     throw error;
   }

--- a/lib/learnworlds/ingestion.ts
+++ b/lib/learnworlds/ingestion.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { learnworldsRawPayloads, learnworldsSyncRuns } from '@/lib/db/schema';
+import { fetchLearnworldsProgressData } from './client';
+import {
+  LearnworldsIngestionResult,
+  LearnworldsProgressRecord,
+  LearnworldsTriggerMode,
+} from './types';
+
+function toTimestampOrNull(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+}
+
+function toBoundedProgress(value: number | null): number | null {
+  if (value === null || Number.isNaN(value)) {
+    return null;
+  }
+
+  const rounded = Math.round(value);
+  if (rounded < 0) {
+    return 0;
+  }
+
+  if (rounded > 100) {
+    return 100;
+  }
+
+  return rounded;
+}
+
+function hashRecord(record: LearnworldsProgressRecord): string {
+  return createHash('sha256').update(JSON.stringify(record.raw)).digest('hex');
+}
+
+export async function runLearnworldsIngestion(
+  triggerMode: LearnworldsTriggerMode = 'manual'
+): Promise<LearnworldsIngestionResult> {
+  const [syncRun] = await db
+    .insert(learnworldsSyncRuns)
+    .values({
+      triggerMode,
+      status: 'running',
+      startedAt: new Date().toISOString(),
+    })
+    .returning({ id: learnworldsSyncRuns.id });
+
+  if (!syncRun?.id) {
+    throw new Error('Failed to create LearnWorlds sync run');
+  }
+
+  try {
+    const fetched = await fetchLearnworldsProgressData();
+
+    if (fetched.records.length > 0) {
+      await db.insert(learnworldsRawPayloads).values(
+        fetched.records.map((record) => ({
+          syncRunId: syncRun.id,
+          sourceEndpoint: fetched.endpoint,
+          httpStatus: fetched.httpStatus,
+          learnerExternalId: record.learnerId,
+          courseExternalId: record.courseId,
+          moduleExternalId: record.moduleId,
+          lessonExternalId: record.lessonId,
+          completionStatus: record.completionStatus,
+          progressPercentage: toBoundedProgress(record.progressPercentage),
+          lastActivityTimestamp: toTimestampOrNull(record.lastActivityTimestamp),
+          recordHash: hashRecord(record),
+          payload: record.raw,
+          receivedAt: new Date().toISOString(),
+        }))
+      );
+    }
+
+    const totalRecords = fetched.records.length;
+    const validRecords = fetched.records.length;
+    const invalidRecords = 0;
+
+    await db
+      .update(learnworldsSyncRuns)
+      .set({
+        status: 'succeeded',
+        totalRecords,
+        validRecords,
+        invalidRecords,
+        finishedAt: new Date().toISOString(),
+      })
+      .where(eq(learnworldsSyncRuns.id, syncRun.id));
+
+    return {
+      syncRunId: syncRun.id,
+      totalRecords,
+      validRecords,
+      invalidRecords,
+    };
+  } catch (error) {
+    const safeErrorMessage =
+      error instanceof Error ? error.message.slice(0, 500) : 'Unknown LearnWorlds ingestion error';
+
+    await db
+      .update(learnworldsSyncRuns)
+      .set({
+        status: 'failed',
+        totalRecords: 0,
+        validRecords: 0,
+        invalidRecords: 0,
+        errorMessage: safeErrorMessage,
+        finishedAt: new Date().toISOString(),
+      })
+      .where(eq(learnworldsSyncRuns.id, syncRun.id));
+
+    throw error;
+  }
+}

--- a/lib/learnworlds/ingestion.ts
+++ b/lib/learnworlds/ingestion.ts
@@ -82,9 +82,9 @@ export async function runLearnworldsIngestion(
       );
     }
 
-    const totalRecords = fetched.records.length;
+    const totalRecords = fetched.rawCount;
     const validRecords = fetched.records.length;
-    const invalidRecords = 0;
+    const invalidRecords = Math.max(0, totalRecords - validRecords);
 
     await db
       .update(learnworldsSyncRuns)

--- a/lib/learnworlds/types.ts
+++ b/lib/learnworlds/types.ts
@@ -20,6 +20,7 @@ export interface LearnworldsIngestionResult {
 
 export interface LearnworldsFetchResponse {
   records: LearnworldsProgressRecord[];
+  rawCount: number;
   endpoint: string;
   httpStatus: number;
 }

--- a/lib/learnworlds/types.ts
+++ b/lib/learnworlds/types.ts
@@ -1,0 +1,25 @@
+export type LearnworldsTriggerMode = 'manual' | 'scheduled' | 'webhook';
+
+export interface LearnworldsProgressRecord {
+  learnerId: string;
+  courseId: string;
+  moduleId: string | null;
+  lessonId: string | null;
+  completionStatus: string | null;
+  progressPercentage: number | null;
+  lastActivityTimestamp: string | null;
+  raw: Record<string, unknown>;
+}
+
+export interface LearnworldsIngestionResult {
+  syncRunId: string;
+  totalRecords: number;
+  validRecords: number;
+  invalidRecords: number;
+}
+
+export interface LearnworldsFetchResponse {
+  records: LearnworldsProgressRecord[];
+  endpoint: string;
+  httpStatus: number;
+}

--- a/tests/learnworlds-ingest-api.spec.ts
+++ b/tests/learnworlds-ingest-api.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from '@playwright/test';
+import { uniqueTestEmail } from './test-utils/create-unique-email';
+import { createTestUser } from './test-utils/create-test-user';
+import { cleanupTestUserById } from './test-utils/delete-test-user';
+
+const TEST_PASSWORD = 'UniqueTestPassphrase28940!';
+
+async function login(page: Page, email: string, password: string, expectedPath: RegExp) {
+  await page.goto('/auth/login', { waitUntil: 'networkidle' });
+  await page.getByLabel('Email').fill(email);
+  await page.locator('#password').fill(password);
+
+  await Promise.all([
+    page.getByRole('button', { name: 'Login', exact: true }).click(),
+    page.waitForURL(expectedPath, { timeout: 30000 }),
+  ]);
+}
+
+test.describe('POST /api/admin/learnworlds/ingest', () => {
+  test('redirects unauthenticated request to login', async ({ request }) => {
+    const response = await request.post('/api/admin/learnworlds/ingest', {
+      maxRedirects: 0,
+    });
+
+    expect([302, 303, 307, 308]).toContain(response.status());
+    const location = response.headers()['location'];
+    expect(location).toContain('/auth/login');
+  });
+
+  test('returns 401 for authenticated non-admin user', async ({ page }) => {
+    const email = uniqueTestEmail('judge');
+    const userId = await createTestUser(email, TEST_PASSWORD, 'judge');
+
+    try {
+      await login(page, email, TEST_PASSWORD, /\/judge/);
+
+      const response = await page.request.post('/api/admin/learnworlds/ingest');
+      expect(response.status()).toBe(401);
+
+      const body = await response.json();
+      expect(body.error).toBe('Unauthorized');
+    } finally {
+      await cleanupTestUserById(userId);
+    }
+  });
+
+  test('returns 400 for invalid trigger mode when admin', async ({ page }) => {
+    const email = uniqueTestEmail('judge');
+    const userId = await createTestUser(email, TEST_PASSWORD, 'admin');
+
+    try {
+      await login(page, email, TEST_PASSWORD, /\/admin/);
+
+      const response = await page.request.post('/api/admin/learnworlds/ingest', {
+        data: {
+          triggerMode: 'invalid_mode',
+        },
+      });
+
+      expect(response.status()).toBe(400);
+      const body = await response.json();
+      expect(body.error).toBe('Invalid triggerMode value');
+    } finally {
+      await cleanupTestUserById(userId);
+    }
+  });
+
+  test('returns controlled response for admin manual ingestion trigger', async ({ page }) => {
+    const email = uniqueTestEmail('judge');
+    const userId = await createTestUser(email, TEST_PASSWORD, 'admin');
+
+    try {
+      await login(page, email, TEST_PASSWORD, /\/admin/);
+
+      const response = await page.request.post('/api/admin/learnworlds/ingest', {
+        data: {
+          triggerMode: 'manual',
+        },
+      });
+
+      expect([200, 500, 502]).toContain(response.status());
+      const body = await response.json();
+
+      if (response.status() === 200) {
+        expect(body.status).toBe('ok');
+        expect(typeof body.syncRunId).toBe('string');
+      } else {
+        expect(typeof body.error).toBe('string');
+        expect(body.error.length).toBeGreaterThan(0);
+      }
+    } finally {
+      await cleanupTestUserById(userId);
+    }
+  });
+});

--- a/tests/learnworlds-ingest-api.spec.ts
+++ b/tests/learnworlds-ingest-api.spec.ts
@@ -84,6 +84,12 @@ test.describe('POST /api/admin/learnworlds/ingest', () => {
       if (response.status() === 200) {
         expect(body.status).toBe('ok');
         expect(typeof body.syncRunId).toBe('string');
+        expect(typeof body.totalRecords).toBe('number');
+        expect(typeof body.validRecords).toBe('number');
+        expect(typeof body.invalidRecords).toBe('number');
+        expect(body.totalRecords).toBeGreaterThanOrEqual(body.validRecords);
+        expect(body.validRecords).toBeGreaterThanOrEqual(0);
+        expect(body.invalidRecords).toBe(body.totalRecords - body.validRecords);
       } else {
         expect(typeof body.error).toBe('string');
         expect(body.error.length).toBeGreaterThan(0);

--- a/tests/test-utils/create-test-user.ts
+++ b/tests/test-utils/create-test-user.ts
@@ -1,0 +1,80 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+type TestUserRole = 'admin' | 'judge' | 'participant';
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  throw new Error('Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in env');
+}
+
+if (process.env.ALLOW_TEST_UTILITIES !== 'true') {
+  throw new Error(
+    'Set ALLOW_TEST_UTILITIES=true in .env.local to run test utilities. ' +
+      'Never set this in production!'
+  );
+}
+
+async function updateUserRoleWithRetry(userId: string, role: TestUserRole): Promise<void> {
+  const updateUrl = `${SUPABASE_URL}/rest/v1/users?id=eq.${userId}`;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const updateRes = await fetch(updateUrl, {
+      method: 'PATCH',
+      headers: {
+        apikey: SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ role }),
+    });
+
+    if (updateRes.ok) {
+      return;
+    }
+
+    if (attempt === 4) {
+      const body = await updateRes.text();
+      throw new Error(`[createTestUser] Failed updating role (${updateRes.status}): ${body}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+  }
+}
+
+export async function createTestUser(
+  email: string,
+  password: string,
+  role: TestUserRole
+): Promise<string> {
+  const createUrl = `${SUPABASE_URL}/auth/v1/admin/users`;
+
+  const createRes = await fetch(createUrl, {
+    method: 'POST',
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { role },
+    }),
+  });
+
+  if (!createRes.ok) {
+    const body = await createRes.text();
+    throw new Error(`[createTestUser] Auth user create failed ${createRes.status}: ${body}`);
+  }
+
+  const created = await createRes.json();
+  const userId: string | undefined = created?.id ?? created?.user?.id;
+
+  if (!userId) {
+    throw new Error('[createTestUser] Created user response missing id');
+  }
+
+  await updateUserRoleWithRetry(userId, role);
+  return userId;
+}

--- a/tests/test-utils/delete-test-user.ts
+++ b/tests/test-utils/delete-test-user.ts
@@ -1,6 +1,11 @@
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
+interface AdminUserSummary {
+  id: string;
+  email?: string;
+}
+
 if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
   throw new Error('Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in env');
 }
@@ -35,9 +40,9 @@ export async function getUserIdByEmail(email: string): Promise<string> {
   }
 
   const data = await res.json();
-  const users = data.users || [];
+  const users: AdminUserSummary[] = Array.isArray(data.users) ? data.users : [];
 
-  const matchedUser = users.find((u: any) => u.email === email);
+  const matchedUser = users.find((u) => u.email === email);
   if (!matchedUser) {
     throw new Error(`[getUserIdByEmail] No user found for ${email}`);
   }


### PR DESCRIPTION
### Title
IC-11 feat: implement LearnWorlds ingestion client and admin trigger endpoint

---

## Summary
This PR implements IC-11 by adding a secure, read-only LearnWorlds ingestion client and an internal admin-triggered ingestion endpoint, with Playwright coverage for endpoint auth and validation behavior.

---

## Related Issue
Closes IC-11 
Closes IC-12 

---

## What’s Included

### LearnWorlds Client Service
- OAuth2 client-credentials token flow  
- HTTPS-only configuration validation  
- Required request headers support (`Authorization`, `Lw-Client`)  
- Timeout handling  
- Retry/backoff behavior for transient failures and rate limiting  

### Ingestion Orchestrator
- Creates sync run records  
- Fetches LearnWorlds progress/activity data  
- Stores raw payload records for traceability  
- Updates sync run status and safe error messages  

### Internal Admin Endpoint
- `POST /api/admin/learnworlds/ingest`  
- Admin-only access check  
- Trigger mode validation (`manual`, `scheduled`, `webhook`)  
- Controlled error responses for config/auth/fetch failures  

### Playwright Tests
- Unauthenticated flow (redirect to login via middleware)  
- Authenticated non-admin returns unauthorized  
- Admin invalid trigger mode returns bad request  
- Admin manual trigger returns controlled success/failure response shape  

### Test Utility Refactor
- Extracted user provisioning into `create-test-user` utility  

---

## Why This Change
This establishes a reliable, secure IC-11 ingestion foundation that reads from LearnWorlds only and persists ingestion metadata for downstream processing (IC-13+), while keeping authentication and operational failures controlled and observable.

---

## Validation
- New Playwright spec passes locally after environment setup  
- Lint/type checks for new files pass  
- Endpoint behavior aligns with current middleware redirect model for unauthenticated requests  

---

## Notes
- API remains read-only against LearnWorlds  
- Current unauthenticated API expectation is redirect (middleware behavior), not direct JSON 401  
- Uses existing sync and raw staging tables introduced in prior schema phase  

---

## PR Checklist

### Functionality
- [ ] Ingestion client authenticates and fetches data correctly  
- [ ] Admin endpoint triggers ingestion successfully  
- [ ] Trigger mode validation works as expected  

### Security
- [ ] Admin-only access enforced correctly  
- [ ] No secrets exposed in logs  
- [ ] HTTPS enforced for outbound calls  

### Reliability
- [ ] Retry/backoff logic handles transient failures  
- [ ] Timeout handling works correctly  
- [ ] Controlled error responses returned  

### Testing
- [ ] Playwright tests pass locally  
- [ ] Auth flows (unauthenticated, non-admin, admin) behave correctly  
- [ ] Success/failure response shapes are consistent  

### Code Quality
- [ ] Code follows project conventions  
- [ ] No TypeScript errors  

### CI / Formatting
- [ ] Prettier passes
- [ ] Linting passes
- [ ] GitHub Actions checks are green