### PR TITLE
Innovation Challenge Page on Learnworlds

### DIFF
--- a/app/api/admin/metrics/route.ts
+++ b/app/api/admin/metrics/route.ts
@@ -15,23 +15,20 @@ import { eq } from 'drizzle-orm';
 export async function GET() {
   try {
     const user = await getUserFromSession();
-    
-  // Only admins can access this endpoint
+
+    // Only admins can access this endpoint
     if (!user || user.role !== 'admin') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     // Query total learners (participants)
-    const learners = await db
-      .select()
-      .from(users)
-      .where(eq(users.role, 'participant'));
-    
-// TODO: Replace placeholder metrics with real analytics queries from the database
+    const learners = await db.select().from(users).where(eq(users.role, 'participant'));
+
+    // TODO: Replace placeholder metrics with real analytics queries from the database
     const metrics = {
       totalRecommendationRequests: 0,
       mostFrequentlyRecommendedItems: [],
-      totalLearnersServed: learners.length, 
+      totalLearnersServed: learners.length,
       averageResponseTime: 0,
     };
 


### PR DESCRIPTION
### Innovation Challenge Page

#### Summary

This PR introduces the Innovation Challenge Page in LearnWorlds, which serves as the entry point for learners to view and access active events from active Judge Portal events.
#### Description

The Innovation Challenge Page hosts a custom challenge widget and will integrate with the Retrieve Challenge Data API (FR-1) to display challenges to the user.

#### Implementation Details

* Created new LearnWorlds page with slug: `/innovation-challenges`
* Configured SEO metadata
* Set visibility to public (logged-in users only)
* Added embed container for the challenge widget integration

#### Access

The page can be accessed at:
https://nleats.learnworlds.com/innovation-challenges

#### Notes

* No code changes required for this task (platform configuration only)
* Widget integration and recommendation engine hookup will be handled in subsequent tasks

#### Next Steps

* Integrate challenge widget into embed container
* Connect to Challenge Recommendation Engine (FR-8)
* Validate personalized challenge rendering
