### PR TITLE
feat(MD-07): Implement Public Mentors API Endpoint

### DIFF
--- a/app/api/mentors/route.ts
+++ b/app/api/mentors/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { mentorProfiles } from '@/lib/db/schema';
+import { getLearnworldsCorsHeaders } from '@/lib/api/cors';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: getLearnworldsCorsHeaders(request),
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const corsHeaders = getLearnworldsCorsHeaders(request);
+
+  try {
+    const mentors = await db
+      .select({
+        id: mentorProfiles.id,
+        fullName: mentorProfiles.fullName,
+        title: mentorProfiles.title,
+        organization: mentorProfiles.organization,
+        bio: mentorProfiles.bio,
+        photoUrl: mentorProfiles.photoUrl,
+        tags: mentorProfiles.tags,
+        linkedinUrl: mentorProfiles.linkedinUrl,
+        calendlyUrl: mentorProfiles.calendlyUrl,
+      })
+      .from(mentorProfiles)
+      .where(eq(mentorProfiles.isVisible, true));
+
+    return NextResponse.json({ mentors }, { headers: corsHeaders });
+  } catch (error) {
+    console.error('Error fetching mentors:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500, headers: corsHeaders }
+    );
+  }
+}

--- a/lib/api/cors.ts
+++ b/lib/api/cors.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+
+export function getLearnworldsCorsHeaders(request: NextRequest): Record<string, string> {
+  const allowedOrigin = process.env.LEARNWORLDS_ALLOWED_ORIGIN;
+  const requestOrigin = request.headers.get('origin');
+  const origin = allowedOrigin && requestOrigin === allowedOrigin ? allowedOrigin : undefined;
+
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'GET,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  };
+  if (origin) headers['Access-Control-Allow-Origin'] = origin;
+  return headers;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,6 +16,6 @@ export const config = {
      * - api/challenges (public API endpoint)
      * Feel free to modify this pattern to include more paths.
      */
-    '/((?!_next/static|_next/image|favicon.ico|api/challenges|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon.ico|api/challenges|api/mentors|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };


### PR DESCRIPTION
Closes #68 

Implemented a public GET endpoint at /api/mentors to support the external LearnWorlds mentor widget in fetching the mentor list.

**Dependencies**
---
 #90 MD-05
- MD-07 is implemented based on the mentorsProfile table created in MD-05.

**Added and Modified Files**
---
- `app/api/mentors/route.ts` (Added)
  - Handles GET requests to fetch mentor data.
  - Filters profiles to only return those where is_visible is true.
- `lib/api/cors.ts` (Added)
  - Contains getCorsHeaders.
  - Future endpoints can use this to maintain consistency. 
- `middleware.ts` (Modified)
  - Updated the matcher/logic to allow public access to /api/mentors by adding the "api/mentors" path.