### PR TITLE
feat(MD-08): Configure LearnWorlds Webhook

### DIFF
--- a/app/api/webhooks/learnworlds/mentor/route.ts
+++ b/app/api/webhooks/learnworlds/mentor/route.ts
@@ -43,6 +43,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Malformed JSON' }, { status: 400 });
     }
 
+    const tags = payload.tags || [];
+
+    if (!Array.isArray(tags) || !tags.includes('role_mentor')) {
+      console.log('Webhook ignored: User does not have the role_mentor tag.');
+      return NextResponse.json({ message: 'Ignored: No mentor tag' }, { status: 200 });
+    }
+
     const userId = payload.user_id || payload.id;
     const fullName = payload.name || payload.full_name || 'Unknown';
 

--- a/tests/mentor-webhook.spec.ts
+++ b/tests/mentor-webhook.spec.ts
@@ -18,6 +18,7 @@ const validPayload = {
   cf_mentor_bio: '10 years of experience in residential real estate.',
   cf_mentor_linkedin: 'https://linkedin.com/in/janedoe',
   cf_mentor_calendly: 'https://calendly.com/janedoe',
+  tags: ['role_mentor'],
 };
 
 test.describe('Mentor webhook endpoint', () => {
@@ -52,6 +53,18 @@ test.describe('Mentor webhook endpoint with configured secret', () => {
     });
 
     expect(response.status()).toBe(401);
+  });
+
+  test('ignores webhook missing the role_mentor tag', async ({ request }) => {
+    const payloadWithoutTag = { ...validPayload, tags: ['student_tag'] };
+    const response = await request.post(WEBHOOK_URL, {
+      headers: { 'x-lw-signature': signPayload(payloadWithoutTag) },
+      data: payloadWithoutTag,
+    });
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.message).toBe('Ignored: No mentor tag');
   });
 
   test('rejects payload missing user_id', async ({ request }) => {


### PR DESCRIPTION
Updated the LearnWorlds mentor webhook endpoint so webhooks that do not contain the role_mentor tag are ignored. 

Files Changed
---
- app/api/webhooks/learnworlds/mentor/route.ts
  - If the role_mentor tag is missing, the request is ignored and a 200 OK status is sent back.
- tests/mentor-webhook.spec.ts
  - Updated the validPayload to include the role_mentor tag.
  - Added a new test case: ignores webhook missing the role_mentor tag.

Additional Notes
---
This depends on #106 MD-06 (webhook receiver for mentor registration) as it updates the endpoint to ignore webhooks without the role_mentor tag.

Implements part of https://github.com/Freddie-Pike/judge-portal/issues/69