### PR TITLE
IC-21 feat: add ingestion health monitoring and staleness check

### DIFF
--- a/app/api/admin/learnworlds/health/route.ts
+++ b/app/api/admin/learnworlds/health/route.ts
@@ -1,0 +1,36 @@
+/**
+ * Admin LearnWorlds Ingestion Health Endpoint
+ * GET /api/admin/learnworlds/health
+ *
+ * Returns the current health and staleness status of the LearnWorlds ingestion pipeline.
+ * Access is restricted to users with the admin role.
+ */
+
+import { NextResponse } from 'next/server';
+import { getUserFromSession } from '@/lib/auth/server';
+import { getIngestionHealthStatus } from '@/lib/learnworlds/health';
+import { sendApiError } from '@/lib/utils/api-errors';
+
+export async function GET() {
+  try {
+    const user = await getUserFromSession();
+
+    // Only admins can access this endpoint
+    if (!user || user.role !== 'admin') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Query the database for the latest ingestion run status
+    const healthReport = await getIngestionHealthStatus();
+
+    // Determine the HTTP status code based on health.
+    // 200 OK for healthy/stale, 503 Service Unavailable if actively failing
+    const httpStatus = healthReport.status === 'failing' ? 503 : 200;
+
+    return NextResponse.json(healthReport, { status: httpStatus });
+    
+  } catch (error) {
+    console.error('Failed to retrieve ingestion health:', error);
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Failed to calculate ingestion health status.');
+  }
+}

--- a/app/api/admin/learnworlds/health/route.ts
+++ b/app/api/admin/learnworlds/health/route.ts
@@ -28,9 +28,12 @@ export async function GET() {
     const httpStatus = healthReport.status === 'failing' ? 503 : 200;
 
     return NextResponse.json(healthReport, { status: httpStatus });
-    
   } catch (error) {
     console.error('Failed to retrieve ingestion health:', error);
-    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Failed to calculate ingestion health status.');
+    return sendApiError(
+      500,
+      'INTERNAL_SERVER_ERROR',
+      'Failed to calculate ingestion health status.'
+    );
   }
 }

--- a/lib/learnworlds/health.ts
+++ b/lib/learnworlds/health.ts
@@ -1,0 +1,65 @@
+import { db } from '@/lib/db';
+import { desc } from 'drizzle-orm';
+import { learnworldsSyncRuns } from '@/lib/db/schema';
+
+export type IngestionHealthStatus = 'healthy' | 'stale' | 'failing' | 'unknown';
+
+/**
+ * Define health report shape
+ */
+export interface IngestionHealthReport {
+  status: IngestionHealthStatus;
+  message: string;
+  lastRunAt: string | null;
+  errorDetails?: string | null;
+}
+
+/**
+ * Generate asynchronous function that returns health report, default threshold is 24h
+ */
+export async function getIngestionHealthStatus(): Promise<IngestionHealthReport> {
+  const thresholdHours = Number(process.env.LEARNWORLDS_STALENESS_THRESHOLD_HOURS || '24');
+  const thresholdMs = thresholdHours * 60 * 60 * 1000;
+    
+  const [lastRun] = await db
+    .select()
+    .from(learnworldsSyncRuns)
+    .orderBy(desc(learnworldsSyncRuns.startedAt))
+    .limit(1);
+
+  if (!lastRun) {
+    return {
+      status: 'unknown',
+      message: 'No LearnWorlds ingestion activity found.',
+      lastRunAt: null,
+    };
+  }
+
+  if (lastRun.status === 'failed') {
+    return {
+      status: 'failing',
+      message: `The last ingestion run failed. Ingestion pipeline is failing.`,
+      lastRunAt: lastRun.finishedAt || lastRun.startedAt,
+      errorDetails: lastRun.errorMessage,
+    };
+  }
+
+  const timestampToEvaluate = lastRun.finishedAt || lastRun.startedAt;
+  const lastRunTime = new Date(timestampToEvaluate).getTime();
+  const timeSinceLastRunMs = Date.now() - lastRunTime;
+
+  if (timeSinceLastRunMs > thresholdMs) {
+    const hoursStale = Math.round(timeSinceLastRunMs / (60 * 60 * 1000));
+    return {
+      status: 'stale',
+      message: `Data is stale. The last successful ingestion was ${hoursStale} hours ago (Threshold: ${thresholdHours}h).`,
+      lastRunAt: timestampToEvaluate,
+    };
+  }
+
+  return {
+    status: 'healthy',
+    message: 'Ingestion pipeline is running normally. Data is up to date.',
+    lastRunAt: timestampToEvaluate,
+  };
+}

--- a/lib/learnworlds/health.ts
+++ b/lib/learnworlds/health.ts
@@ -20,7 +20,7 @@ export interface IngestionHealthReport {
 export async function getIngestionHealthStatus(): Promise<IngestionHealthReport> {
   const thresholdHours = Number(process.env.LEARNWORLDS_STALENESS_THRESHOLD_HOURS || '24');
   const thresholdMs = thresholdHours * 60 * 60 * 1000;
-    
+
   const [lastRun] = await db
     .select()
     .from(learnworldsSyncRuns)


### PR DESCRIPTION
Closes IC-21, related to FR-15 Service Health Monitoring Endpoint
## Summary
This PR introduces a health monitoring utility for the LearnWorlds ingestion pipeline. By querying the `learnworlds_sync_runs` table via Drizzle, it determines if the data feeding our recommendation engine is up-to-date, failing, or stale. It also exposes an admin-secured API endpoint to integrate with our broader FR-15 service health monitoring.

## Changes
- `lib/learnworlds/health.ts`: Core logic for checking sync run recency and status. Defines `IngestionHealthReport` which returns a status, message, the last run time, and error details. Checks the most recent ingestion in the `learnworlds_sync_runs` table and returns the status of the pipeline. 
- app/api/admin/learnworlds/health/route.ts: Admin endpoint to expose the health status. Checks the user is an admin and waits for the health report from `getIngestionHealthStatus`. Returns health report and http status. Utilizes `sendApiError` for errors.

## Notes
- Dependencies: PR #103  for `sendApiError` utility. PR #97 for `learnworldsSyncRuns` table.