### PR TITLE
FR-10: Build Recommendation Widget

### DIFF
--- a/app/participant/recommendations/page.tsx
+++ b/app/participant/recommendations/page.tsx
@@ -1,0 +1,18 @@
+import { RecommendationWidget } from "@/components/rec-widget";
+
+/**
+ * Mentor page
+ */
+export default function MentorPage() {
+  return (
+    <main className="min-h-screen bg-background pb-20">
+      <div className="container mx-auto px-4 py-12">
+        
+        <section className="rounded-xl border bg-card/50 p-4 md:p-8">
+          <RecommendationWidget />
+        </section>
+        
+      </div>
+    </main>
+  );
+}

--- a/app/participant/recommendations/page.tsx
+++ b/app/participant/recommendations/page.tsx
@@ -1,4 +1,4 @@
-import { RecommendationWidget } from "@/components/rec-widget";
+import { RecommendationWidget } from '@/components/rec-widget';
 
 /**
  * Mentor page
@@ -7,11 +7,9 @@ export default function MentorPage() {
   return (
     <main className="min-h-screen bg-background pb-20">
       <div className="container mx-auto px-4 py-12">
-        
         <section className="rounded-xl border bg-card/50 p-4 md:p-8">
           <RecommendationWidget />
         </section>
-        
       </div>
     </main>
   );

--- a/components/rec-widget.tsx
+++ b/components/rec-widget.tsx
@@ -10,6 +10,7 @@ interface RecommendationResponse {
   rationale: string;
 }
 
+// Mock Data -- To be replaced with API response
 const MOCK_DATA: RecommendationResponse = {
   learner_id: '123',
   recommended_item_id: 'COURSE_456',
@@ -35,6 +36,7 @@ export function RecommendationWidget() {
     return (
       <div className="flex justify-center py-20">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <span className="sr-only">Loading recommendation...</span>
       </div>
     );
   }
@@ -56,11 +58,10 @@ export function RecommendationWidget() {
           </p>
         </div>
 
-        {/* Right Side: Recommendation Card (Replacing Video) */}
+        {/* Right Side: Recommendation Card */}
         <div className="w-full lg:w-2/3">
           <div className="group relative overflow-hidden rounded-2xl border bg-card p-8 shadow-sm transition-all hover:shadow-md hover:border-primary/50">
             <div className="flex flex-col md:flex-row md:items-center gap-6">
-              {/* Icon/Visual Anchor */}
               <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
                 <BookOpen className="h-8 w-8" />
               </div>
@@ -76,7 +77,7 @@ export function RecommendationWidget() {
                 <p className="text-muted-foreground">{data.rationale}</p>
               </div>
 
-              {/* Action */}
+              {/* Content Link: When content source is provided, will link to content source */}
               <div className="pt-4 md:pt-0">
                 <button className="flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition-all hover:opacity-90">
                   Start Now
@@ -85,7 +86,7 @@ export function RecommendationWidget() {
               </div>
             </div>
 
-            {/* Subtle background decoration */}
+            {/* Background decoration */}
             <div className="absolute -right-8 -top-8 h-32 w-32 rounded-full bg-primary/5 blur-3xl group-hover:bg-primary/10 transition-colors" />
           </div>
         </div>

--- a/components/rec-widget.tsx
+++ b/components/rec-widget.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
 import { Sparkles, Loader2 } from 'lucide-react';
 
 interface Recommendation {
@@ -48,7 +47,6 @@ export function RecommendationWidget() {
           - Row (flex-row) and large gap on desktop.
       */}
       <div className="flex flex-col lg:flex-row gap-12 items-start">
-        
         {/* Left Side: Text */}
         <div className="w-full lg:w-1/3 space-y-4">
           <div className="flex items-center gap-2 text-primary font-bold text-xs uppercase tracking-wider">
@@ -59,9 +57,7 @@ export function RecommendationWidget() {
           <p className="text-muted-foreground text-lg">{data.rationale}</p>
         </div>
 
-        {/* Right Side: Video 
-            - lg:w-2/3 makes the video take up the majority of the row.
-        */}
+        {/* Right Side: Video */}
         <div className="w-full lg:w-2/3">
           <div className="relative aspect-video w-full rounded-xl bg-black border shadow-lg overflow-hidden">
             <iframe
@@ -72,7 +68,6 @@ export function RecommendationWidget() {
             />
           </div>
         </div>
-
       </div>
     </div>
   );

--- a/components/rec-widget.tsx
+++ b/components/rec-widget.tsx
@@ -1,24 +1,25 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Sparkles, Loader2 } from 'lucide-react';
+import { Sparkles, Loader2, ArrowRight, BookOpen } from 'lucide-react';
 
-interface Recommendation {
-  id: string;
-  title: string;
+interface RecommendationResponse {
+  learner_id: string;
+  recommended_item_id: string;
+  recommended_title: string;
   rationale: string;
-  video_url: string;
 }
 
-const MOCK_DATA: Recommendation = {
-  id: 'rec-fr-10',
-  title: 'Video title',
-  rationale: 'Based on your recent history, this video will help you with your training.',
-  video_url: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+const MOCK_DATA: RecommendationResponse = {
+  learner_id: '123',
+  recommended_item_id: 'COURSE_456',
+  recommended_title: 'Advanced Food Safety',
+  rationale:
+    'Since you completed Food Safety Basics, this course will help you master professional kitchen protocols.',
 };
 
 export function RecommendationWidget() {
-  const [data, setData] = useState<Recommendation | null>(null);
+  const [data, setData] = useState<RecommendationResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -42,30 +43,50 @@ export function RecommendationWidget() {
 
   return (
     <div className="w-full max-w-7xl mx-auto py-12 px-6">
-      {/* Main Layout: 
-          - Stacked (flex-col) on mobile. 
-          - Row (flex-row) and large gap on desktop.
-      */}
-      <div className="flex flex-col lg:flex-row gap-12 items-start">
-        {/* Left Side: Text */}
+      <div className="flex flex-col lg:flex-row gap-12 items-center">
+        {/* Left Side: Header & Context */}
         <div className="w-full lg:w-1/3 space-y-4">
           <div className="flex items-center gap-2 text-primary font-bold text-xs uppercase tracking-wider">
             <Sparkles className="h-4 w-4" />
             Recommended
           </div>
-          <h3 className="text-4xl font-extrabold">{data.title}</h3>
-          <p className="text-muted-foreground text-lg">{data.rationale}</p>
+          <h3 className="text-4xl font-extrabold tracking-tight">Your Next Step</h3>
+          <p className="text-muted-foreground text-lg leading-relaxed">
+            We've analyzed your progress to find the best path forward for your training.
+          </p>
         </div>
 
-        {/* Right Side: Video */}
+        {/* Right Side: Recommendation Card (Replacing Video) */}
         <div className="w-full lg:w-2/3">
-          <div className="relative aspect-video w-full rounded-xl bg-black border shadow-lg overflow-hidden">
-            <iframe
-              src={data.video_url}
-              className="absolute inset-0 h-full w-full border-0"
-              allowFullScreen
-              title="Recommendation Video"
-            />
+          <div className="group relative overflow-hidden rounded-2xl border bg-card p-8 shadow-sm transition-all hover:shadow-md hover:border-primary/50">
+            <div className="flex flex-col md:flex-row md:items-center gap-6">
+              {/* Icon/Visual Anchor */}
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                <BookOpen className="h-8 w-8" />
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 space-y-2">
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-normal">
+                  ID: {data.recommended_item_id}
+                </span>
+                <h4 className="text-2xl font-bold group-hover:text-primary transition-colors">
+                  {data.recommended_title}
+                </h4>
+                <p className="text-muted-foreground">{data.rationale}</p>
+              </div>
+
+              {/* Action */}
+              <div className="pt-4 md:pt-0">
+                <button className="flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition-all hover:opacity-90">
+                  Start Now
+                  <ArrowRight className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Subtle background decoration */}
+            <div className="absolute -right-8 -top-8 h-32 w-32 rounded-full bg-primary/5 blur-3xl group-hover:bg-primary/10 transition-colors" />
           </div>
         </div>
       </div>

--- a/components/rec-widget.tsx
+++ b/components/rec-widget.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Sparkles, Loader2 } from 'lucide-react';
+
+interface Recommendation {
+  id: string;
+  title: string;
+  rationale: string;
+  video_url: string;
+}
+
+const MOCK_DATA: Recommendation = {
+  id: 'rec-fr-10',
+  title: 'Video title',
+  rationale: 'Based on your recent history, this video will help you with your training.',
+  video_url: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+};
+
+export function RecommendationWidget() {
+  const [data, setData] = useState<Recommendation | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      setData(MOCK_DATA);
+      setIsLoading(false);
+    }, 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-20">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="w-full max-w-7xl mx-auto py-12 px-6">
+      {/* Main Layout: 
+          - Stacked (flex-col) on mobile. 
+          - Row (flex-row) and large gap on desktop.
+      */}
+      <div className="flex flex-col lg:flex-row gap-12 items-start">
+        
+        {/* Left Side: Text */}
+        <div className="w-full lg:w-1/3 space-y-4">
+          <div className="flex items-center gap-2 text-primary font-bold text-xs uppercase tracking-wider">
+            <Sparkles className="h-4 w-4" />
+            Recommended
+          </div>
+          <h3 className="text-4xl font-extrabold">{data.title}</h3>
+          <p className="text-muted-foreground text-lg">{data.rationale}</p>
+        </div>
+
+        {/* Right Side: Video 
+            - lg:w-2/3 makes the video take up the majority of the row.
+        */}
+        <div className="w-full lg:w-2/3">
+          <div className="relative aspect-video w-full rounded-xl bg-black border shadow-lg overflow-hidden">
+            <iframe
+              src={data.video_url}
+              className="absolute inset-0 h-full w-full border-0"
+              allowFullScreen
+              title="Recommendation Video"
+            />
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/components/rec-widget.tsx
+++ b/components/rec-widget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Sparkles, Loader2, ArrowRight, BookOpen } from 'lucide-react';
+import { Sparkles, Loader2, ArrowRight, BookOpen, Star, X } from 'lucide-react';
 
 interface RecommendationResponse {
   learner_id: string;
@@ -21,7 +21,7 @@ const MOCK_DATA: RecommendationResponse = {
 
 export function RecommendationWidget() {
   const [data, setData] = useState<RecommendationResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     setIsLoading(true);
@@ -54,7 +54,7 @@ export function RecommendationWidget() {
           </div>
           <h3 className="text-4xl font-extrabold tracking-tight">Your Next Step</h3>
           <p className="text-muted-foreground text-lg leading-relaxed">
-            We've analyzed your progress to find the best path forward for your training.
+            We have analyzed your progress to find the best path forward for your training.
           </p>
         </div>
 

--- a/components/rec-widget.tsx
+++ b/components/rec-widget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Sparkles, Loader2, ArrowRight, BookOpen, Star, X } from 'lucide-react';
+import { Sparkles, Loader2, ArrowRight, BookOpen } from 'lucide-react';
 
 interface RecommendationResponse {
   learner_id: string;


### PR DESCRIPTION
Implemented a new widget that displays a recommended course (title, id, and rationale) to users.

Changes
- New Page: app/participant/recommendations/page.tsx
- New Component: components/rec-widget.tsx
- Split-Screen Layout: Implemented a 1:2 text-to-recommendation ratio on desktop that stacks on mobile
- Loading state before data is rendered

Notes
- This widget currently uses mock data for testing
- Page can be accessed by adding `/recommendations` to the participant home page

Closes #124 