### PR TITLE
feat: add personalized recommendation schema foundation (IC-26,  IC-29, IC-30, IC-31, IC-32, IC-34, IC-45)

### DIFF
--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -4,11 +4,14 @@ import {
   text,
   timestamp,
   integer,
+  numeric,
+  jsonb,
   unique,
   check,
   index,
   pgEnum,
   boolean,
+  AnyPgColumn,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
@@ -343,6 +346,362 @@ export const competitions = pgTable(
   })
 );
 
+export const learnerRecommendations = pgTable(
+  'learner_recommendations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    learnworldsUserId: text('learnworlds_user_id').notNull(),
+    recommendedItemId: text('recommended_item_id').notNull(),
+    recommendedItemType: text('recommended_item_type'),
+    recommendedTitle: text('recommended_title').notNull(),
+    rationale: text('rationale').notNull(),
+    source: text('source').default('rule').notNull(),
+    ruleMatched: text('rule_matched'),
+    modelVersion: text('model_version'),
+    score: numeric('score', { precision: 12, scale: 6 }),
+    generatedAt: timestamp('generated_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'string' }),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    learnworldsUserIdx: index('idx_learner_recommendations_learnworlds_user').on(
+      table.learnworldsUserId
+    ),
+    generatedAtIdx: index('idx_learner_recommendations_generated_at').on(table.generatedAt),
+    userGeneratedAtIdx: index('idx_learner_recommendations_user_generated_at').on(
+      table.learnworldsUserId,
+      table.generatedAt
+    ),
+    checkSource: check(
+      'check_learner_recommendations_source',
+      sql`${table.source} IN ('rule', 'ml', 'fallback')`
+    ),
+  })
+);
+
+export const learnerItemEvents = pgTable(
+  'learner_item_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    learnworldsUserId: text('learnworlds_user_id').notNull(),
+    itemId: text('item_id').notNull(),
+    itemType: text('item_type').notNull(),
+    eventType: text('event_type').notNull(),
+    eventValue: numeric('event_value', { precision: 12, scale: 6 }),
+    eventTimestamp: timestamp('event_timestamp', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+    source: text('source').default('system').notNull(),
+    metadata: jsonb('metadata'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    learnworldsUserIdx: index('idx_learner_item_events_learnworlds_user').on(
+      table.learnworldsUserId
+    ),
+    itemIdx: index('idx_learner_item_events_item').on(table.itemId),
+    eventTypeIdx: index('idx_learner_item_events_event_type').on(table.eventType),
+    eventTimestampIdx: index('idx_learner_item_events_event_timestamp').on(table.eventTimestamp),
+    userEventTimestampIdx: index('idx_learner_item_events_user_event_timestamp').on(
+      table.learnworldsUserId,
+      table.eventTimestamp
+    ),
+    checkItemType: check(
+      'check_learner_item_events_item_type',
+      sql`${table.itemType} IN ('course', 'module', 'lesson', 'challenge', 'recommendation')`
+    ),
+    checkEventType: check(
+      'check_learner_item_events_event_type',
+      sql`${table.eventType} IN ('viewed', 'started', 'progressed', 'completed', 'recommendation_clicked', 'recommendation_ignored', 'feedback_submitted')`
+    ),
+    checkSource: check(
+      'check_learner_item_events_source',
+      sql`${table.source} IN ('learnworlds', 'widget', 'api', 'system')`
+    ),
+  })
+);
+
+export const recommendationImpressions = pgTable(
+  'recommendation_impressions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    recommendationId: uuid('recommendation_id')
+      .references(() => learnerRecommendations.id, { onDelete: 'cascade' })
+      .notNull(),
+    learnworldsUserId: text('learnworlds_user_id').notNull(),
+    itemId: text('item_id').notNull(),
+    itemType: text('item_type'),
+    source: text('source').default('api').notNull(),
+    modelVersion: text('model_version'),
+    score: numeric('score', { precision: 12, scale: 6 }),
+    rankPosition: integer('rank_position'),
+    shownAt: timestamp('shown_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    recommendationIdx: index('idx_recommendation_impressions_recommendation').on(
+      table.recommendationId
+    ),
+    learnworldsUserIdx: index('idx_recommendation_impressions_learnworlds_user').on(
+      table.learnworldsUserId
+    ),
+    userShownAtIdx: index('idx_recommendation_impressions_user_shown_at').on(
+      table.learnworldsUserId,
+      table.shownAt
+    ),
+    checkItemType: check(
+      'check_recommendation_impressions_item_type',
+      sql`${table.itemType} IS NULL OR ${table.itemType} IN ('course', 'module', 'lesson', 'challenge', 'recommendation')`
+    ),
+    checkRankPosition: check(
+      'check_recommendation_impressions_rank_position',
+      sql`${table.rankPosition} IS NULL OR ${table.rankPosition} >= 1`
+    ),
+  })
+);
+
+export const recommendationOutcomes = pgTable(
+  'recommendation_outcomes',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    recommendationImpressionId: uuid('recommendation_impression_id')
+      .references(() => recommendationImpressions.id, { onDelete: 'cascade' })
+      .notNull(),
+    learnworldsUserId: text('learnworlds_user_id').notNull(),
+    itemId: text('item_id').notNull(),
+    outcomeType: text('outcome_type').notNull(),
+    labelValue: integer('label_value'),
+    outcomeTimestamp: timestamp('outcome_timestamp', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+    metadata: jsonb('metadata'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    impressionIdx: index('idx_recommendation_outcomes_impression').on(
+      table.recommendationImpressionId
+    ),
+    learnworldsUserIdx: index('idx_recommendation_outcomes_learnworlds_user').on(
+      table.learnworldsUserId
+    ),
+    outcomeTypeIdx: index('idx_recommendation_outcomes_outcome_type').on(table.outcomeType),
+    userOutcomeTimestampIdx: index('idx_recommendation_outcomes_user_outcome_timestamp').on(
+      table.learnworldsUserId,
+      table.outcomeTimestamp
+    ),
+    checkOutcomeType: check(
+      'check_recommendation_outcomes_outcome_type',
+      sql`${table.outcomeType} IN ('clicked', 'started', 'completed', 'dismissed', 'no_action')`
+    ),
+    checkLabelValue: check(
+      'check_recommendation_outcomes_label_value',
+      sql`${table.labelValue} IS NULL OR ${table.labelValue} IN (0, 1)`
+    ),
+  })
+);
+
+export const recommendationFeedback = pgTable(
+  'recommendation_feedback',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    recommendationId: uuid('recommendation_id').references(() => learnerRecommendations.id, {
+      onDelete: 'cascade',
+    }),
+    learnworldsUserId: text('learnworlds_user_id').notNull(),
+    recommendedItemId: text('recommended_item_id').notNull(),
+    feedbackType: text('feedback_type'),
+    rating: integer('rating'),
+    comment: text('comment'),
+    submittedAt: timestamp('submitted_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    recommendationIdx: index('idx_recommendation_feedback_recommendation').on(
+      table.recommendationId
+    ),
+    learnworldsUserIdx: index('idx_recommendation_feedback_learnworlds_user').on(
+      table.learnworldsUserId
+    ),
+    checkFeedbackType: check(
+      'check_recommendation_feedback_feedback_type',
+      sql`${table.feedbackType} IS NULL OR ${table.feedbackType} IN ('helpful', 'not_helpful')`
+    ),
+    checkRating: check(
+      'check_recommendation_feedback_rating',
+      sql`${table.rating} IS NULL OR (${table.rating} >= 1 AND ${table.rating} <= 5)`
+    ),
+  })
+);
+
+export const learningItems = pgTable(
+  'learning_items',
+  {
+    itemId: text('item_id').primaryKey(),
+    itemType: text('item_type').notNull(),
+    title: text('title').notNull(),
+    description: text('description'),
+    category: text('category'),
+    difficultyLevel: text('difficulty_level'),
+    estimatedDurationMinutes: integer('estimated_duration_minutes'),
+    prerequisiteItemId: text('prerequisite_item_id').references(
+      (): AnyPgColumn => learningItems.itemId,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    isActive: boolean('is_active').default(true).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    itemTypeIdx: index('idx_learning_items_item_type').on(table.itemType),
+    categoryIdx: index('idx_learning_items_category').on(table.category),
+    isActiveIdx: index('idx_learning_items_is_active').on(table.isActive),
+    checkItemType: check(
+      'check_learning_items_item_type',
+      sql`${table.itemType} IN ('course', 'module', 'lesson')`
+    ),
+    checkEstimatedDuration: check(
+      'check_learning_items_estimated_duration',
+      sql`${table.estimatedDurationMinutes} IS NULL OR ${table.estimatedDurationMinutes} >= 0`
+    ),
+  })
+);
+
+export const mlTrainingExamples = pgTable(
+  'ml_training_examples',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    learnworldsUserId: text('learnworlds_user_id').notNull(),
+    candidateItemId: text('candidate_item_id').notNull(),
+    snapshotTime: timestamp('snapshot_time', { withTimezone: true, mode: 'string' }).notNull(),
+    totalItemsStarted: integer('total_items_started'),
+    totalItemsCompleted: integer('total_items_completed'),
+    completionRate: numeric('completion_rate', { precision: 12, scale: 6 }),
+    avgProgressPercentage: numeric('avg_progress_percentage', { precision: 12, scale: 6 }),
+    daysSinceLastActivity: integer('days_since_last_activity'),
+    activeCoursesCount: integer('active_courses_count'),
+    completedCoursesCount: integer('completed_courses_count'),
+    preferredCategory: text('preferred_category'),
+    preferredDifficulty: text('preferred_difficulty'),
+    itemType: text('item_type'),
+    itemCategory: text('item_category'),
+    itemDifficulty: text('item_difficulty'),
+    itemDurationMinutes: integer('item_duration_minutes'),
+    hasPrerequisite: boolean('has_prerequisite'),
+    isPrerequisiteCompleted: boolean('is_prerequisite_completed'),
+    candidatePopularity7d: integer('candidate_popularity_7d'),
+    candidateCompletionRate30d: numeric('candidate_completion_rate_30d', {
+      precision: 12,
+      scale: 6,
+    }),
+    sameCategoryAsRecentActivity: boolean('same_category_as_recent_activity'),
+    sameDifficultyAsRecentActivity: boolean('same_difficulty_as_recent_activity'),
+    learnworldsUserHasSeenItemBefore: boolean('learnworlds_user_has_seen_item_before'),
+    learnworldsUserStartedSimilarItemsBefore: boolean(
+      'learnworlds_user_started_similar_items_before'
+    ),
+    learnworldsUserCompletedPrerequisite: boolean('learnworlds_user_completed_prerequisite'),
+    candidateIsNextInPath: boolean('candidate_is_next_in_path'),
+    candidatePreviouslyIgnored: boolean('candidate_previously_ignored'),
+    labelEngaged: integer('label_engaged').notNull(),
+    split: text('split').notNull(),
+    modelingWindowStart: timestamp('modeling_window_start', { withTimezone: true, mode: 'string' }),
+    modelingWindowEnd: timestamp('modeling_window_end', { withTimezone: true, mode: 'string' }),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    learnworldsUserIdx: index('idx_ml_training_examples_learnworlds_user').on(
+      table.learnworldsUserId
+    ),
+    candidateItemIdx: index('idx_ml_training_examples_candidate_item').on(table.candidateItemId),
+    splitIdx: index('idx_ml_training_examples_split').on(table.split),
+    checkSplit: check(
+      'check_ml_training_examples_split',
+      sql`${table.split} IN ('train', 'validation', 'test')`
+    ),
+    checkLabelEngaged: check(
+      'check_ml_training_examples_label_engaged',
+      sql`${table.labelEngaged} IN (0, 1)`
+    ),
+    checkTotalItemsStarted: check(
+      'check_ml_training_examples_total_items_started',
+      sql`${table.totalItemsStarted} IS NULL OR ${table.totalItemsStarted} >= 0`
+    ),
+    checkTotalItemsCompleted: check(
+      'check_ml_training_examples_total_items_completed',
+      sql`${table.totalItemsCompleted} IS NULL OR ${table.totalItemsCompleted} >= 0`
+    ),
+    checkDaysSinceLastActivity: check(
+      'check_ml_training_examples_days_since_last_activity',
+      sql`${table.daysSinceLastActivity} IS NULL OR ${table.daysSinceLastActivity} >= 0`
+    ),
+    checkActiveCoursesCount: check(
+      'check_ml_training_examples_active_courses_count',
+      sql`${table.activeCoursesCount} IS NULL OR ${table.activeCoursesCount} >= 0`
+    ),
+    checkCompletedCoursesCount: check(
+      'check_ml_training_examples_completed_courses_count',
+      sql`${table.completedCoursesCount} IS NULL OR ${table.completedCoursesCount} >= 0`
+    ),
+    checkItemDurationMinutes: check(
+      'check_ml_training_examples_item_duration_minutes',
+      sql`${table.itemDurationMinutes} IS NULL OR ${table.itemDurationMinutes} >= 0`
+    ),
+    checkCandidatePopularity7d: check(
+      'check_ml_training_examples_candidate_popularity_7d',
+      sql`${table.candidatePopularity7d} IS NULL OR ${table.candidatePopularity7d} >= 0`
+    ),
+  })
+);
+
+export const modelRegistry = pgTable(
+  'model_registry',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    modelVersion: text('model_version').notNull().unique(),
+    modelType: text('model_type').notNull(),
+    featureSchemaVersion: text('feature_schema_version').notNull(),
+    artifactPath: text('artifact_path').notNull(),
+    trainingStart: timestamp('training_start', { withTimezone: true, mode: 'string' }),
+    trainingEnd: timestamp('training_end', { withTimezone: true, mode: 'string' }),
+    isActive: boolean('is_active').default(false).notNull(),
+    metrics: jsonb('metrics'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' })
+      .default(sql`timezone('utc'::text, now())`)
+      .notNull(),
+  },
+  (table) => ({
+    isActiveIdx: index('idx_model_registry_is_active').on(table.isActive),
+    checkModelType: check(
+      'check_model_registry_model_type',
+      sql`${table.modelType} IN ('logistic_regression', 'xgboost', 'lightgbm')`
+    ),
+  })
+);
+
 export type Organization = typeof organizations.$inferSelect;
 export type NewOrganization = typeof organizations.$inferInsert;
 export type Event = typeof events.$inferSelect;
@@ -367,3 +726,19 @@ export type OrganizationMember = typeof organizationMembers.$inferSelect;
 export type NewOrganizationMember = typeof organizationMembers.$inferInsert;
 export type Competition = typeof competitions.$inferSelect;
 export type NewCompetition = typeof competitions.$inferInsert;
+export type LearnerRecommendation = typeof learnerRecommendations.$inferSelect;
+export type NewLearnerRecommendation = typeof learnerRecommendations.$inferInsert;
+export type LearnerItemEvent = typeof learnerItemEvents.$inferSelect;
+export type NewLearnerItemEvent = typeof learnerItemEvents.$inferInsert;
+export type RecommendationImpression = typeof recommendationImpressions.$inferSelect;
+export type NewRecommendationImpression = typeof recommendationImpressions.$inferInsert;
+export type RecommendationOutcome = typeof recommendationOutcomes.$inferSelect;
+export type NewRecommendationOutcome = typeof recommendationOutcomes.$inferInsert;
+export type RecommendationFeedback = typeof recommendationFeedback.$inferSelect;
+export type NewRecommendationFeedback = typeof recommendationFeedback.$inferInsert;
+export type LearningItem = typeof learningItems.$inferSelect;
+export type NewLearningItem = typeof learningItems.$inferInsert;
+export type MlTrainingExample = typeof mlTrainingExamples.$inferSelect;
+export type NewMlTrainingExample = typeof mlTrainingExamples.$inferInsert;
+export type ModelRegistry = typeof modelRegistry.$inferSelect;
+export type NewModelRegistry = typeof modelRegistry.$inferInsert;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -431,9 +431,9 @@ export const recommendationImpressions = pgTable(
   'recommendation_impressions',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    recommendationId: uuid('recommendation_id')
-      .references(() => learnerRecommendations.id, { onDelete: 'cascade' })
-      .notNull(),
+    recommendationId: uuid('recommendation_id').references(() => learnerRecommendations.id, {
+      onDelete: 'set null',
+    }),
     learnworldsUserId: text('learnworlds_user_id').notNull(),
     itemId: text('item_id').notNull(),
     itemType: text('item_type'),
@@ -474,9 +474,10 @@ export const recommendationOutcomes = pgTable(
   'recommendation_outcomes',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    recommendationImpressionId: uuid('recommendation_impression_id')
-      .references(() => recommendationImpressions.id, { onDelete: 'cascade' })
-      .notNull(),
+    recommendationImpressionId: uuid('recommendation_impression_id').references(
+      () => recommendationImpressions.id,
+      { onDelete: 'set null' }
+    ),
     learnworldsUserId: text('learnworlds_user_id').notNull(),
     itemId: text('item_id').notNull(),
     outcomeType: text('outcome_type').notNull(),
@@ -517,7 +518,7 @@ export const recommendationFeedback = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     recommendationId: uuid('recommendation_id').references(() => learnerRecommendations.id, {
-      onDelete: 'cascade',
+      onDelete: 'set null',
     }),
     learnworldsUserId: text('learnworlds_user_id').notNull(),
     recommendedItemId: text('recommended_item_id').notNull(),

--- a/supabase/migrations/features/006_personalized-learning-recommendation-foundation.sql
+++ b/supabase/migrations/features/006_personalized-learning-recommendation-foundation.sql
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS learner_item_events (
 
 CREATE TABLE IF NOT EXISTS recommendation_impressions (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-  recommendation_id UUID NOT NULL REFERENCES learner_recommendations(id) ON DELETE CASCADE,
+  recommendation_id UUID REFERENCES learner_recommendations(id) ON DELETE SET NULL,
   learnworlds_user_id TEXT NOT NULL,
   item_id TEXT NOT NULL,
   item_type TEXT,
@@ -82,8 +82,8 @@ CREATE TABLE IF NOT EXISTS recommendation_impressions (
 
 CREATE TABLE IF NOT EXISTS recommendation_outcomes (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-  recommendation_impression_id UUID NOT NULL
-    REFERENCES recommendation_impressions(id) ON DELETE CASCADE,
+  recommendation_impression_id UUID
+    REFERENCES recommendation_impressions(id) ON DELETE SET NULL,
   learnworlds_user_id TEXT NOT NULL,
   item_id TEXT NOT NULL,
   outcome_type TEXT NOT NULL,
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS recommendation_outcomes (
 
 CREATE TABLE IF NOT EXISTS recommendation_feedback (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-  recommendation_id UUID REFERENCES learner_recommendations(id) ON DELETE CASCADE,
+  recommendation_id UUID REFERENCES learner_recommendations(id) ON DELETE SET NULL,
   learnworlds_user_id TEXT NOT NULL,
   recommended_item_id TEXT NOT NULL,
   feedback_type TEXT,

--- a/supabase/migrations/features/006_personalized-learning-recommendation-foundation.sql
+++ b/supabase/migrations/features/006_personalized-learning-recommendation-foundation.sql
@@ -1,0 +1,291 @@
+-- ================================================================
+-- FEATURE: Personalized learning recommendation foundation
+-- Description: Adds recommendation tracking, feedback, item catalog,
+--              ML training examples, and model registry tables
+-- Dependencies: consolidated_setup.sql, 001_invite-link.sql,
+--               002_multi-tenant-participants.sql,
+--               003_competitions.sql,
+--               005_learnworlds-ingestion-foundation.sql
+-- ================================================================
+
+-- ================================================================
+-- SECTION 1: RECOMMENDATION CORE TABLES
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS learner_recommendations (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  learnworlds_user_id TEXT NOT NULL,
+  recommended_item_id TEXT NOT NULL,
+  recommended_item_type TEXT,
+  recommended_title TEXT NOT NULL,
+  rationale TEXT NOT NULL,
+  source TEXT DEFAULT 'rule' NOT NULL,
+  rule_matched TEXT,
+  model_version TEXT,
+  score NUMERIC(12, 6),
+  generated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  expires_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_learner_recommendations_source
+    CHECK (source IN ('rule', 'ml', 'fallback'))
+);
+
+CREATE TABLE IF NOT EXISTS learner_item_events (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  learnworlds_user_id TEXT NOT NULL,
+  item_id TEXT NOT NULL,
+  item_type TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_value NUMERIC(12, 6),
+  event_timestamp TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  source TEXT DEFAULT 'system' NOT NULL,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_learner_item_events_item_type
+    CHECK (item_type IN ('course', 'module', 'lesson', 'challenge', 'recommendation')),
+  CONSTRAINT check_learner_item_events_event_type
+    CHECK (
+      event_type IN (
+        'viewed',
+        'started',
+        'progressed',
+        'completed',
+        'recommendation_clicked',
+        'recommendation_ignored',
+        'feedback_submitted'
+      )
+    ),
+  CONSTRAINT check_learner_item_events_source
+    CHECK (source IN ('learnworlds', 'widget', 'api', 'system'))
+);
+
+CREATE TABLE IF NOT EXISTS recommendation_impressions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  recommendation_id UUID NOT NULL REFERENCES learner_recommendations(id) ON DELETE CASCADE,
+  learnworlds_user_id TEXT NOT NULL,
+  item_id TEXT NOT NULL,
+  item_type TEXT,
+  source TEXT DEFAULT 'api' NOT NULL,
+  model_version TEXT,
+  score NUMERIC(12, 6),
+  rank_position INTEGER,
+  shown_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_recommendation_impressions_item_type
+    CHECK (
+      item_type IS NULL OR
+      item_type IN ('course', 'module', 'lesson', 'challenge', 'recommendation')
+    ),
+  CONSTRAINT check_recommendation_impressions_rank_position
+    CHECK (rank_position IS NULL OR rank_position >= 1)
+);
+
+CREATE TABLE IF NOT EXISTS recommendation_outcomes (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  recommendation_impression_id UUID NOT NULL
+    REFERENCES recommendation_impressions(id) ON DELETE CASCADE,
+  learnworlds_user_id TEXT NOT NULL,
+  item_id TEXT NOT NULL,
+  outcome_type TEXT NOT NULL,
+  label_value INTEGER,
+  outcome_timestamp TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  metadata JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_recommendation_outcomes_outcome_type
+    CHECK (outcome_type IN ('clicked', 'started', 'completed', 'dismissed', 'no_action')),
+  CONSTRAINT check_recommendation_outcomes_label_value
+    CHECK (label_value IS NULL OR label_value IN (0, 1))
+);
+
+CREATE TABLE IF NOT EXISTS recommendation_feedback (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  recommendation_id UUID REFERENCES learner_recommendations(id) ON DELETE CASCADE,
+  learnworlds_user_id TEXT NOT NULL,
+  recommended_item_id TEXT NOT NULL,
+  feedback_type TEXT,
+  rating INTEGER,
+  comment TEXT,
+  submitted_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_recommendation_feedback_feedback_type
+    CHECK (feedback_type IS NULL OR feedback_type IN ('helpful', 'not_helpful')),
+  CONSTRAINT check_recommendation_feedback_rating
+    CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5))
+);
+
+-- ================================================================
+-- SECTION 2: ITEM CATALOG + ML DATA TABLES
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS learning_items (
+  item_id TEXT PRIMARY KEY,
+  item_type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  category TEXT,
+  difficulty_level TEXT,
+  estimated_duration_minutes INTEGER,
+  prerequisite_item_id TEXT REFERENCES learning_items(item_id) ON DELETE SET NULL,
+  is_active BOOLEAN DEFAULT TRUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_learning_items_item_type
+    CHECK (item_type IN ('course', 'module', 'lesson')),
+  CONSTRAINT check_learning_items_estimated_duration
+    CHECK (estimated_duration_minutes IS NULL OR estimated_duration_minutes >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS ml_training_examples (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  learnworlds_user_id TEXT NOT NULL,
+  candidate_item_id TEXT NOT NULL,
+  snapshot_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  total_items_started INTEGER,
+  total_items_completed INTEGER,
+  completion_rate NUMERIC(12, 6),
+  avg_progress_percentage NUMERIC(12, 6),
+  days_since_last_activity INTEGER,
+  active_courses_count INTEGER,
+  completed_courses_count INTEGER,
+  preferred_category TEXT,
+  preferred_difficulty TEXT,
+  item_type TEXT,
+  item_category TEXT,
+  item_difficulty TEXT,
+  item_duration_minutes INTEGER,
+  has_prerequisite BOOLEAN,
+  is_prerequisite_completed BOOLEAN,
+  candidate_popularity_7d INTEGER,
+  candidate_completion_rate_30d NUMERIC(12, 6),
+  same_category_as_recent_activity BOOLEAN,
+  same_difficulty_as_recent_activity BOOLEAN,
+  learnworlds_user_has_seen_item_before BOOLEAN,
+  learnworlds_user_started_similar_items_before BOOLEAN,
+  learnworlds_user_completed_prerequisite BOOLEAN,
+  candidate_is_next_in_path BOOLEAN,
+  candidate_previously_ignored BOOLEAN,
+  label_engaged INTEGER NOT NULL,
+  split TEXT NOT NULL,
+  modeling_window_start TIMESTAMP WITH TIME ZONE,
+  modeling_window_end TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_ml_training_examples_split
+    CHECK (split IN ('train', 'validation', 'test')),
+  CONSTRAINT check_ml_training_examples_label_engaged
+    CHECK (label_engaged IN (0, 1)),
+  CONSTRAINT check_ml_training_examples_total_items_started
+    CHECK (total_items_started IS NULL OR total_items_started >= 0),
+  CONSTRAINT check_ml_training_examples_total_items_completed
+    CHECK (total_items_completed IS NULL OR total_items_completed >= 0),
+  CONSTRAINT check_ml_training_examples_days_since_last_activity
+    CHECK (days_since_last_activity IS NULL OR days_since_last_activity >= 0),
+  CONSTRAINT check_ml_training_examples_active_courses_count
+    CHECK (active_courses_count IS NULL OR active_courses_count >= 0),
+  CONSTRAINT check_ml_training_examples_completed_courses_count
+    CHECK (completed_courses_count IS NULL OR completed_courses_count >= 0),
+  CONSTRAINT check_ml_training_examples_item_duration_minutes
+    CHECK (item_duration_minutes IS NULL OR item_duration_minutes >= 0),
+  CONSTRAINT check_ml_training_examples_candidate_popularity_7d
+    CHECK (candidate_popularity_7d IS NULL OR candidate_popularity_7d >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS model_registry (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  model_version TEXT NOT NULL UNIQUE,
+  model_type TEXT NOT NULL,
+  feature_schema_version TEXT NOT NULL,
+  artifact_path TEXT NOT NULL,
+  training_start TIMESTAMP WITH TIME ZONE,
+  training_end TIMESTAMP WITH TIME ZONE,
+  is_active BOOLEAN DEFAULT FALSE NOT NULL,
+  metrics JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  CONSTRAINT check_model_registry_model_type
+    CHECK (model_type IN ('logistic_regression', 'xgboost', 'lightgbm'))
+);
+
+-- ================================================================
+-- SECTION 3: INDEXES
+-- ================================================================
+
+CREATE INDEX IF NOT EXISTS idx_learner_recommendations_learnworlds_user
+  ON learner_recommendations(learnworlds_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_learner_recommendations_generated_at
+  ON learner_recommendations(generated_at);
+
+CREATE INDEX IF NOT EXISTS idx_learner_recommendations_user_generated_at
+  ON learner_recommendations(learnworlds_user_id, generated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_learner_item_events_learnworlds_user
+  ON learner_item_events(learnworlds_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_learner_item_events_item
+  ON learner_item_events(item_id);
+
+CREATE INDEX IF NOT EXISTS idx_learner_item_events_event_type
+  ON learner_item_events(event_type);
+
+CREATE INDEX IF NOT EXISTS idx_learner_item_events_event_timestamp
+  ON learner_item_events(event_timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_learner_item_events_user_event_timestamp
+  ON learner_item_events(learnworlds_user_id, event_timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_impressions_recommendation
+  ON recommendation_impressions(recommendation_id);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_impressions_learnworlds_user
+  ON recommendation_impressions(learnworlds_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_impressions_user_shown_at
+  ON recommendation_impressions(learnworlds_user_id, shown_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_outcomes_impression
+  ON recommendation_outcomes(recommendation_impression_id);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_outcomes_learnworlds_user
+  ON recommendation_outcomes(learnworlds_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_outcomes_outcome_type
+  ON recommendation_outcomes(outcome_type);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_outcomes_user_outcome_timestamp
+  ON recommendation_outcomes(learnworlds_user_id, outcome_timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_feedback_recommendation
+  ON recommendation_feedback(recommendation_id);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_feedback_learnworlds_user
+  ON recommendation_feedback(learnworlds_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_learning_items_item_type
+  ON learning_items(item_type);
+
+CREATE INDEX IF NOT EXISTS idx_learning_items_category
+  ON learning_items(category);
+
+CREATE INDEX IF NOT EXISTS idx_learning_items_is_active
+  ON learning_items(is_active);
+
+CREATE INDEX IF NOT EXISTS idx_ml_training_examples_learnworlds_user
+  ON ml_training_examples(learnworlds_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_ml_training_examples_candidate_item
+  ON ml_training_examples(candidate_item_id);
+
+CREATE INDEX IF NOT EXISTS idx_ml_training_examples_split
+  ON ml_training_examples(split);
+
+CREATE INDEX IF NOT EXISTS idx_model_registry_is_active
+  ON model_registry(is_active);
+
+-- ================================================================
+-- SUCCESS MESSAGE
+-- ================================================================
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Feature "personalized-learning-recommendation-foundation" migration completed successfully!';
+  RAISE NOTICE 'Created tables: learner_recommendations, learner_item_events, recommendation_impressions, recommendation_outcomes, recommendation_feedback, learning_items, ml_training_examples, model_registry';
+END $$;


### PR DESCRIPTION
## PR Title
feat: add personalized recommendation schema foundation (IC-26,  IC-29, IC-30, IC-31, IC-32, IC-34, IC-45)

---

## PR Description

Closes #128, #131, #132, #133, #134, #136, and #149.

### Summary

Implemented the personalized recommendation and data-science schema foundation for the LMS.

### What’s Included

Added new feature migration for recommendation / data-science tables:
- learner_recommendations
- learner_item_events
- recommendation_impressions
- recommendation_outcomes
- recommendation_feedback
- learning_items
- ml_training_examples
- model_registry

Added matching Drizzle schema definitions and exported types for all of the above.

### Design & Consistency

- Kept naming aligned with LearnWorlds integration using:
  - `learnworlds_user_id` (SQL)
  - `learnworldsUserId` (Drizzle)

- Maintained consistency with existing migration patterns:
  - idempotent table/index creation
  - UTC timestamp defaults
  - structured, sectioned migration layout
  - success logging

### Data Integrity & Constraints

Added constraints and indexes to ensure quality and performance:
- enum-like validation using CHECK constraints (event_type, source, outcome_type, etc.)
- rating bounds (1–5) and non-negative checks (scores, counts, ranks)
- composite indexes for user + time access patterns
- foreign key relationships:
  - recommendation → impressions → outcomes
  - self-referential prerequisite relationship in `learning_items`

### Issue Coverage

This PR provides the schema foundation for:

- **IC-26** → learner_recommendations  
- **IC-30** → learner_item_events  
- **IC-31** → recommendation_impressions, recommendation_outcomes  
- **IC-32** → recommendation_feedback  
- **IC-34** → learning_items, ml_training_examples  
- **IC-45** → model_registry  

### Validation

- Lint passed after schema integration  
- Migration follows existing repo conventions  
- Tables and indexes verified locally  