### PR TITLE
Reduce GitHub Actions storage and minute usage

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -2,7 +2,6 @@ name: Lint & Format
 
 on:
   pull_request:
-  push:
 
 jobs:
   lint-and-format:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,6 @@ name: Playwright Tests
 
 on:
   pull_request:
-  push:
 
 jobs:
   playwright-tests:
@@ -63,15 +62,15 @@ jobs:
             kill $(cat .server.pid) || true
           fi
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: failure()
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 30
+          retention-days: 3
       - name: Upload server logs
-        if: ${{ !cancelled() }}
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: server-logs
           path: server.log
-          retention-days: 7
+          retention-days: 3


### PR DESCRIPTION
Our Actions storage is running low. This PR applies three small changes to optimize the storage:

- **Remove `push:` trigger from both workflows.** Now they run once per PR update.
- **Upload Playwright artifacts only on failure.** From now on, artifacts are only kept when we actually need them for debugging.
- **Drop artifact retention from 30/7 days to 3 days.** Failed-run artifacts are useful for a day or two, not a month.