### PR TITLE
Ic 08/filter challenge

### DIFF
--- a/app/api/participant/events/route.ts
+++ b/app/api/participant/events/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getUserFromSession } from '@/lib/auth/server';
 import { db } from '@/lib/db';
-import { events, organizations, eventParticipants } from '@/lib/db/schema';
+import { events, organizations, eventParticipants, competitions } from '@/lib/db/schema';
 import { eq, inArray, sql } from 'drizzle-orm';
 
 export async function GET() {
@@ -23,9 +23,12 @@ export async function GET() {
         createdAt: events.createdAt,
         registrationId: eventParticipants.id,
         registeredAt: eventParticipants.registeredAt,
+        challengeType: competitions.challengeType,
+        tags: competitions.tags,
       })
       .from(events)
       .leftJoin(organizations, eq(events.organizationId, organizations.id))
+      .leftJoin(competitions, eq(events.id, competitions.eventId))
       .leftJoin(
         eventParticipants,
         sql`${eventParticipants.eventId} = ${events.id} AND ${eventParticipants.participantId} = ${user.id}`
@@ -43,6 +46,8 @@ export async function GET() {
       createdAt: e.createdAt,
       isRegistered: e.registrationId !== null,
       registeredAt: e.registeredAt,
+      challengeType: e.challengeType || 'global',
+      challengeTags: e.tags || [],
     }));
 
     return NextResponse.json({ events: result });

--- a/app/participant/components/event-card.tsx
+++ b/app/participant/components/event-card.tsx
@@ -1,5 +1,5 @@
 'use client';
- 
+
 import { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -16,11 +16,11 @@ interface EventCardProps {
 
 export function getEventTags(event: ParticipantEvent): string[] {
   const customTags: string[] = [];
-  
+
   if (event.challengeType) {
     customTags.push(event.challengeType.charAt(0).toUpperCase() + event.challengeType.slice(1));
   }
-  
+
   if (event.challengeTags && event.challengeTags.length > 0) {
     customTags.push(...event.challengeTags);
   } else {
@@ -35,7 +35,7 @@ export function getEventTags(event: ParticipantEvent): string[] {
     if (lower.includes('iot')) customTags.push('IoT');
     if (lower.includes('game')) customTags.push('Gaming');
     if (lower.includes('sustain') || lower.includes('green')) customTags.push('Sustainability');
-    
+
     // Only add defaults if we literally have just the challengeType
     if (customTags.length === 1) customTags.push('Challenge');
     if (customTags.length < 2) customTags.push('Open');

--- a/app/participant/components/event-card.tsx
+++ b/app/participant/components/event-card.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+ 
 import { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -14,22 +14,34 @@ interface EventCardProps {
   onRegister: (eventId: string) => Promise<boolean>;
 }
 
-function getEventTags(name: string): string[] {
-  const lower = name.toLowerCase();
-  const tags: string[] = [];
-  if (lower.includes('hack')) tags.push('Hackathon');
-  if (lower.includes('innov')) tags.push('Innovation');
-  if (lower.includes('ai') || lower.includes('ml')) tags.push('AI/ML');
-  if (lower.includes('web')) tags.push('Web Dev');
-  if (lower.includes('mobile')) tags.push('Mobile');
-  if (lower.includes('data')) tags.push('Data');
-  if (lower.includes('design')) tags.push('Design');
-  if (lower.includes('iot')) tags.push('IoT');
-  if (lower.includes('game')) tags.push('Gaming');
-  if (lower.includes('sustain') || lower.includes('green')) tags.push('Sustainability');
-  if (tags.length === 0) tags.push('Challenge');
-  if (tags.length < 2) tags.push('Open');
-  return tags.slice(0, 3);
+export function getEventTags(event: ParticipantEvent): string[] {
+  const customTags: string[] = [];
+  
+  if (event.challengeType) {
+    customTags.push(event.challengeType.charAt(0).toUpperCase() + event.challengeType.slice(1));
+  }
+  
+  if (event.challengeTags && event.challengeTags.length > 0) {
+    customTags.push(...event.challengeTags);
+  } else {
+    const lower = event.name.toLowerCase();
+    if (lower.includes('hack')) customTags.push('Hackathon');
+    if (lower.includes('innov')) customTags.push('Innovation');
+    if (lower.includes('ai') || lower.includes('ml')) customTags.push('AI/ML');
+    if (lower.includes('web')) customTags.push('Web Dev');
+    if (lower.includes('mobile')) customTags.push('Mobile');
+    if (lower.includes('data')) customTags.push('Data');
+    if (lower.includes('design')) customTags.push('Design');
+    if (lower.includes('iot')) customTags.push('IoT');
+    if (lower.includes('game')) customTags.push('Gaming');
+    if (lower.includes('sustain') || lower.includes('green')) customTags.push('Sustainability');
+    
+    // Only add defaults if we literally have just the challengeType
+    if (customTags.length === 1) customTags.push('Challenge');
+    if (customTags.length < 2) customTags.push('Open');
+  }
+
+  return Array.from(new Set(customTags)).slice(0, 3);
 }
 
 const tagColors = [
@@ -42,7 +54,7 @@ const tagColors = [
 export function EventCard({ event, team, onRegister }: EventCardProps) {
   const [isRegistering, setIsRegistering] = useState(false);
 
-  const tags = getEventTags(event.name);
+  const tags = getEventTags(event);
 
   const handleRegister = async (e: React.MouseEvent) => {
     e.preventDefault();

--- a/app/participant/components/event-card.tsx
+++ b/app/participant/components/event-card.tsx
@@ -35,8 +35,6 @@ export function getEventTags(event: ParticipantEvent): string[] {
     if (lower.includes('iot')) customTags.push('IoT');
     if (lower.includes('game')) customTags.push('Gaming');
     if (lower.includes('sustain') || lower.includes('green')) customTags.push('Sustainability');
-
-    // Only add defaults if we literally have just the challengeType
     if (customTags.length === 1) customTags.push('Challenge');
     if (customTags.length < 2) customTags.push('Open');
   }

--- a/app/participant/contexts/participant-context.tsx
+++ b/app/participant/contexts/participant-context.tsx
@@ -13,6 +13,8 @@ export interface ParticipantEvent {
   createdAt: string;
   isRegistered: boolean;
   registeredAt: string | null;
+  challengeType?: string;
+  challengeTags?: string[];
 }
 
 export interface ParticipantTeam {

--- a/app/participant/event/[eventId]/page.tsx
+++ b/app/participant/event/[eventId]/page.tsx
@@ -55,7 +55,7 @@ export default function EventDetailPage({ params }: { params: Promise<{ eventId:
   const router = useRouter();
   const { events, isLoading, registerForEvent, unregisterFromEvent, getTeamForEvent, refreshAll } =
     useParticipant();
-
+ 
   const [isRegistering, setIsRegistering] = useState(false);
   const [isUnregistering, setIsUnregistering] = useState(false);
   const [showCreateTeam, setShowCreateTeam] = useState(false);

--- a/app/participant/event/[eventId]/page.tsx
+++ b/app/participant/event/[eventId]/page.tsx
@@ -55,7 +55,7 @@ export default function EventDetailPage({ params }: { params: Promise<{ eventId:
   const router = useRouter();
   const { events, isLoading, registerForEvent, unregisterFromEvent, getTeamForEvent, refreshAll } =
     useParticipant();
- 
+
   const [isRegistering, setIsRegistering] = useState(false);
   const [isUnregistering, setIsUnregistering] = useState(false);
   const [showCreateTeam, setShowCreateTeam] = useState(false);

--- a/app/participant/page.tsx
+++ b/app/participant/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { Card } from '@/components/ui/card';
-import { Target, Sparkles, Users, Clock, Rocket, ChevronRight } from 'lucide-react';
+import { Target, Sparkles, Users, Clock, Rocket, ChevronRight, Search, X } from 'lucide-react';
 import { useParticipant } from './contexts/participant-context';
-import { EventCard } from './components/event-card';
+import { EventCard, getEventTags } from './components/event-card';
 import { TeamCard } from './components/team-card';
+import { useState, useMemo } from 'react';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
 
 function SkeletonCard() {
@@ -49,6 +52,40 @@ function SkeletonTeamCard() {
 
 export default function ParticipantPage() {
   const { events, myTeams, isLoading, registerForEvent, getTeamForEvent } = useParticipant();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<string>('All');
+
+  const availableCategories = useMemo(() => {
+    const allTags = new Set<string>();
+    // Pre-populate core categories
+    allTags.add('Global');
+    allTags.add('Local');
+    
+    events.forEach(event => {
+      const tags = getEventTags(event);
+      tags.forEach(tag => allTags.add(tag));
+    });
+    return ['All', ...Array.from(allTags)];
+  }, [events]);
+
+  const filteredEvents = useMemo(() => {
+    return events.filter(event => {
+      const tags = getEventTags(event);
+
+      const matchesSearch =
+        event.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        (event.description?.toLowerCase() || '').includes(searchQuery.toLowerCase());
+
+      const matchesCategory = selectedCategory === 'All' || tags.includes(selectedCategory);
+
+      return matchesSearch && matchesCategory;
+    });
+  }, [events, searchQuery, selectedCategory]);
+
+  const clearFilters = () => {
+    setSearchQuery('');
+    setSelectedCategory('All');
+  };
 
   return (
     <div className="min-h-full">
@@ -126,7 +163,7 @@ export default function ParticipantPage() {
 
         {/* Events section */}
         <div>
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
             <div className="flex items-center gap-2">
               <Sparkles className="h-5 w-5 text-amber-500" />
               <h2 className="text-lg sm:text-xl font-semibold text-foreground">
@@ -134,21 +171,68 @@ export default function ParticipantPage() {
               </h2>
               {!isLoading && (
                 <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">
-                  {events.length}
+                  {filteredEvents.length}
                 </span>
               )}
             </div>
+
+            {/* Search Input Area */}
+            {!isLoading && events.length > 0 && (
+              <div className="relative w-full sm:w-64">
+                <div className="absolute inset-y-0 left-3 flex items-center pointer-events-none">
+                  <Search className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <Input
+                  type="text"
+                  placeholder="Search challenges..."
+                  className="pl-9 pr-4 h-9"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </div>
+            )}
           </div>
 
+          {/* Filter Chips Container */}
+          {!isLoading && events.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-6">
+              {availableCategories.map(category => (
+                <Badge
+                  key={category}
+                  variant={selectedCategory === category ? 'default' : 'outline'}
+                  className={`cursor-pointer transition-colors ${
+                    selectedCategory === category
+                      ? 'bg-teal-600 hover:bg-teal-700 text-white'
+                      : 'hover:bg-muted'
+                  }`}
+                  onClick={() => setSelectedCategory(category)}
+                >
+                  {category}
+                </Badge>
+              ))}
+
+              {/* Show Clear button if any filter is heavily active */}
+              {(searchQuery || selectedCategory !== 'All') && (
+                <button
+                  onClick={clearFilters}
+                  className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 ml-2"
+                >
+                  <X className="h-3 w-3" /> Clear Filters
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Event Cards Grid */}
           {isLoading ? (
             <div className="grid gap-4 sm:gap-6 md:grid-cols-2">
               <SkeletonCard />
               <SkeletonCard />
               <SkeletonCard />
             </div>
-          ) : events.length > 0 ? (
+          ) : filteredEvents.length > 0 ? (
             <div className="grid gap-4 sm:gap-6 md:grid-cols-2">
-              {events.map((event) => (
+              {filteredEvents.map((event) => (
                 <EventCard
                   key={event.id}
                   event={event}
@@ -156,6 +240,24 @@ export default function ParticipantPage() {
                   onRegister={registerForEvent}
                 />
               ))}
+            </div>
+          ) : events.length > 0 ? (
+            <div className="text-center py-10 sm:py-12 bg-muted/20 rounded-xl border border-dashed">
+              <div className="w-14 h-14 mx-auto mb-4 rounded-full bg-muted flex items-center justify-center">
+                <Search className="h-6 w-6 text-muted-foreground" />
+              </div>
+              <h3 className="text-base font-semibold text-foreground mb-2">
+                No challenges found
+              </h3>
+              <p className="text-sm text-muted-foreground max-w-sm mx-auto mb-4">
+                We couldn't find any challenges matching your search or selected category.
+              </p>
+              <button 
+                className="text-sm font-medium text-teal-600 hover:underline"
+                onClick={clearFilters}
+              >
+                Clear filters
+              </button>
             </div>
           ) : (
             <div className="text-center py-10 sm:py-12">

--- a/app/participant/page.tsx
+++ b/app/participant/page.tsx
@@ -60,16 +60,16 @@ export default function ParticipantPage() {
     // Pre-populate core categories
     allTags.add('Global');
     allTags.add('Local');
-    
-    events.forEach(event => {
+
+    events.forEach((event) => {
       const tags = getEventTags(event);
-      tags.forEach(tag => allTags.add(tag));
+      tags.forEach((tag) => allTags.add(tag));
     });
     return ['All', ...Array.from(allTags)];
   }, [events]);
 
   const filteredEvents = useMemo(() => {
-    return events.filter(event => {
+    return events.filter((event) => {
       const tags = getEventTags(event);
 
       const matchesSearch =
@@ -196,7 +196,7 @@ export default function ParticipantPage() {
           {/* Filter Chips Container */}
           {!isLoading && events.length > 0 && (
             <div className="flex flex-wrap gap-2 mb-6">
-              {availableCategories.map(category => (
+              {availableCategories.map((category) => (
                 <Badge
                   key={category}
                   variant={selectedCategory === category ? 'default' : 'outline'}
@@ -246,13 +246,11 @@ export default function ParticipantPage() {
               <div className="w-14 h-14 mx-auto mb-4 rounded-full bg-muted flex items-center justify-center">
                 <Search className="h-6 w-6 text-muted-foreground" />
               </div>
-              <h3 className="text-base font-semibold text-foreground mb-2">
-                No challenges found
-              </h3>
+              <h3 className="text-base font-semibold text-foreground mb-2">No challenges found</h3>
               <p className="text-sm text-muted-foreground max-w-sm mx-auto mb-4">
                 We couldn't find any challenges matching your search or selected category.
               </p>
-              <button 
+              <button
                 className="text-sm font-medium text-teal-600 hover:underline"
                 onClick={clearFilters}
               >

--- a/app/participant/page.tsx
+++ b/app/participant/page.tsx
@@ -57,7 +57,6 @@ export default function ParticipantPage() {
 
   const availableCategories = useMemo(() => {
     const allTags = new Set<string>();
-    // Pre-populate core categories
     allTags.add('Global');
     allTags.add('Local');
 
@@ -248,7 +247,7 @@ export default function ParticipantPage() {
               </div>
               <h3 className="text-base font-semibold text-foreground mb-2">No challenges found</h3>
               <p className="text-sm text-muted-foreground max-w-sm mx-auto mb-4">
-                We couldn't find any challenges matching your search or selected category.
+                We couldn&apos;t find any challenges matching your search or selected category.
               </p>
               <button
                 className="text-sm font-medium text-teal-600 hover:underline"


### PR DESCRIPTION
### Description
This PR resolves the issue for allowing learners to filter the challenge list by text search and category toggles directly without needing page reloads.

### Summary of Changes
* **UI Features:**  Search Bar and Filter Chip container to the Participant Dashboard overview. 
* **State Logic:** Implemented React hooks underneath `ParticipantPage` to filter cards instantaneously. Empty states trigger if zero challenges match the toggles.

### Tasks Completed
- [x] Add Search input field to widget header
- [x] Add Filter Chips container ("Local", "Global", etc.)
- [x] Implement JS logic to filter the DOM elements based on input
- [x] Add "Clear Filters" button

### Acceptance Criteria Reached
- [x] Typing in search bar hides non-matching cards immediately
- [x] Clicking a tag chip shows only relevant challenges
- [x] Empty state message appears if search yields no results

### Testing
- Tested locally by navigating to `/participant` as a participant user.
- Verified visual clarity of search bar. 
- Triggered empty states to confirm the reset "Clear filters" link executes properly.
