### PR TITLE
feat(IC-50): Implement Global Health Check Endpoint

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -5,7 +5,7 @@ import { getIngestionHealthStatus } from '@/lib/learnworlds/health';
 
 export async function GET() {
   const timestamp = new Date().toISOString();
-  
+
   let dbStatus = 'connected';
   let globalStatus = 'healthy';
   let httpStatus = 200;
@@ -28,7 +28,7 @@ export async function GET() {
   if (dbStatus === 'connected') {
     try {
       const ingestionReport = await getIngestionHealthStatus();
-      
+
       ingestionStatus = {
         status: ingestionReport.status,
         lastRunAt: ingestionReport.lastRunAt,
@@ -37,11 +37,10 @@ export async function GET() {
       if (ingestionReport.status === 'failing' || ingestionReport.status === 'stale') {
         globalStatus = 'degraded';
       }
-
     } catch (error) {
       console.error('Health Check failed to retrieve ingestion subsystem health:', error);
       ingestionStatus.status = 'unknown';
-      globalStatus = 'degraded'; 
+      globalStatus = 'degraded';
     }
   }
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { getIngestionHealthStatus } from '@/lib/learnworlds/health';
+
+export async function GET() {
+  const timestamp = new Date().toISOString();
+  
+  let dbStatus = 'connected';
+  let globalStatus = 'healthy';
+  let httpStatus = 200;
+
+  try {
+    await db.execute(sql`SELECT 1`);
+  } catch (error) {
+    console.error('Health Check failed to connect to the database:', error);
+    dbStatus = 'disconnected';
+    globalStatus = 'unavailable';
+    httpStatus = 503;
+  }
+
+  // LearnWorlds Ingestion Check
+  let ingestionStatus = {
+    status: 'unknown',
+    lastRunAt: null as string | null,
+  };
+
+  if (dbStatus === 'connected') {
+    try {
+      const ingestionReport = await getIngestionHealthStatus();
+      
+      ingestionStatus = {
+        status: ingestionReport.status,
+        lastRunAt: ingestionReport.lastRunAt,
+      };
+
+      if (ingestionReport.status === 'failing' || ingestionReport.status === 'stale') {
+        globalStatus = 'degraded';
+      }
+
+    } catch (error) {
+      console.error('Health Check failed to retrieve ingestion subsystem health:', error);
+      ingestionStatus.status = 'unknown';
+      globalStatus = 'degraded'; 
+    }
+  }
+
+  const payload = {
+    status: globalStatus,
+    database: dbStatus,
+    timestamp,
+    subsystems: {
+      ingestion: ingestionStatus,
+    },
+  };
+
+  return NextResponse.json(payload, { status: httpStatus });
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -11,7 +11,10 @@ export async function GET() {
   let httpStatus = 200;
 
   try {
-    await db.execute(sql`SELECT 1`);
+    const timeoutTrigger = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('Database timeout')), 5000)
+    );
+    await Promise.race([db.execute(sql`SELECT 1`), timeoutTrigger]);
   } catch (error) {
     console.error('Health Check failed to connect to the database:', error);
     dbStatus = 'disconnected';
@@ -39,7 +42,7 @@ export async function GET() {
       }
     } catch (error) {
       console.error('Health Check failed to retrieve ingestion subsystem health:', error);
-      ingestionStatus.status = 'unknown';
+      ingestionStatus.status = 'unavailable';
       globalStatus = 'degraded';
     }
   }


### PR DESCRIPTION
Description 
---
Closes: (IC-50) #164 
Fulfills: FR-15 (Service Health Monitoring Endpoint)

This PR adds a centralized `/api/health` endpoint to monitor the Judge Portal's status. It aggregates database connectivity and the LearnWorlds ingestion subsystem into a single diagnostic response.

Overview
---
1. Database: Executes `SELECT 1` to verify the connection. Returns `503` if disconnected.

2. Ingestion: Calls `getIngestionHealthStatus()`. If the sync is failing or stale, the global status becomes degraded but stays `200`.

3. Fault Tolerance: Errors in the ingestion subsystem are caught and reported as degraded rather than crashing the health check.

Dependencies
---
PR #123 implementation of `getIngestionHealthStatus()`.

Sample Response
---
```json
{
  "status": "healthy",
  "database": "connected",
  "timestamp": "2026-04-27T...",
  "subsystems": {
    "ingestion": {
      "status": "healthy",
      "lastRunAt": "..."
    }
  }
}
```