### PR TITLE
Refactor: Implement sendApiError in Admin Criteria Routes

### DIFF
--- a/app/api/admin/criteria/[criterionId]/route.ts
+++ b/app/api/admin/criteria/[criterionId]/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db';
 import { criteria } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getAdminOrgId, requireEventInOrg } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function PUT(
   request: NextRequest,
@@ -16,7 +17,7 @@ export async function PUT(
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -25,33 +26,27 @@ export async function PUT(
       await request.json();
 
     if (!name || !name.trim()) {
-      return NextResponse.json({ error: 'Criteria name is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Criteria name is required');
     }
 
     if (typeof minScore !== 'number' || typeof maxScore !== 'number') {
-      return NextResponse.json({ error: 'Min and max scores must be numbers' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Min and max scores must be numbers');
     }
 
     if (minScore >= maxScore) {
-      return NextResponse.json({ error: 'Min score must be less than max score' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Min score must be less than max score');
     }
 
     if (typeof displayOrder !== 'number') {
-      return NextResponse.json({ error: 'Display order must be a number' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Display order must be a number');
     }
 
     if (typeof weight !== 'number' || weight < 0 || weight > 100) {
-      return NextResponse.json(
-        { error: 'Weight must be a number between 0 and 100' },
-        { status: 400 }
-      );
+      return sendApiError(400, 'BAD_REQUEST', 'Weight must be a number between 0 and 100');
     }
 
     if (!category || !['technical', 'business'].includes(category)) {
-      return NextResponse.json(
-        { error: 'Category must be either "technical" or "business"' },
-        { status: 400 }
-      );
+      return sendApiError(400, 'BAD_REQUEST', 'Category must be either "technical" or "business"');
     }
 
     // Get the current criterion to check its current weight and category
@@ -62,7 +57,7 @@ export async function PUT(
       .limit(1);
 
     if (!currentCriterion) {
-      return NextResponse.json({ error: 'Criterion not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Criterion not found');
     }
 
     // Verify criterion's event belongs to org
@@ -90,11 +85,10 @@ export async function PUT(
 
     // Validate that the category weight total won't exceed 100%
     if (newWeightTotal > 100) {
-      return NextResponse.json(
-        {
-          error: `Cannot update criterion: ${category} category weights would total ${newWeightTotal}% (maximum 100%)`,
-        },
-        { status: 400 }
+      return sendApiError(
+        400,
+        'BAD_REQUEST',
+        `Cannot update criterion: ${category} category weights would total ${newWeightTotal}% (maximum 100%)`
       );
     }
 
@@ -114,7 +108,7 @@ export async function PUT(
       .returning();
 
     if (!criterion) {
-      return NextResponse.json({ error: 'Criterion not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Criterion not found');
     }
 
     return NextResponse.json({ criterion });
@@ -124,20 +118,14 @@ export async function PUT(
     // Handle unique constraint violations
     if (error instanceof Error && error.message.includes('duplicate key')) {
       if (error.message.includes('criteria_event_id_name_key')) {
-        return NextResponse.json(
-          { error: 'A criterion with this name already exists' },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'A criterion with this name already exists');
       }
       if (error.message.includes('criteria_event_id_display_order_key')) {
-        return NextResponse.json(
-          { error: 'A criterion with this display order already exists' },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'A criterion with this display order already exists');
       }
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -152,7 +140,7 @@ export async function DELETE(
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -165,7 +153,7 @@ export async function DELETE(
       .limit(1);
 
     if (!existingCriterion) {
-      return NextResponse.json({ error: 'Criterion not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Criterion not found');
     }
 
     await requireEventInOrg(existingCriterion.eventId, orgId);
@@ -177,12 +165,12 @@ export async function DELETE(
       .returning();
 
     if (!deletedCriterion) {
-      return NextResponse.json({ error: 'Criterion not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Criterion not found');
     }
 
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error deleting criterion:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/criteria/[criterionId]/route.ts
+++ b/app/api/admin/criteria/[criterionId]/route.ts
@@ -61,13 +61,7 @@ export async function PUT(
     }
 
     // Verify criterion's event belongs to org
-    try {
-      await requireEventInOrg(currentCriterion.eventId, orgId);
-    } catch (error: any) {
-      const status = error.status || error.statusCode || 403;
-      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
-      return sendApiError(status, code, error.message || 'Access to event denied');
-    }
+    await requireEventInOrg(currentCriterion.eventId, orgId);
 
     // Get all criteria in the same event to validate weight totals
     const allCriteria = await db
@@ -166,13 +160,7 @@ export async function DELETE(
       return sendApiError(404, 'NOT_FOUND', 'Criterion not found');
     }
 
-    try {
-      await requireEventInOrg(existingCriterion.eventId, orgId);
-    } catch (error: any) {
-      const status = error.status || error.statusCode || 403;
-      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
-      return sendApiError(status, code, error.message || 'Access to event denied');
-    }
+    await requireEventInOrg(existingCriterion.eventId, orgId);
 
     // Delete criterion (cascade will handle related scores)
     const [deletedCriterion] = await db

--- a/app/api/admin/criteria/[criterionId]/route.ts
+++ b/app/api/admin/criteria/[criterionId]/route.ts
@@ -121,7 +121,11 @@ export async function PUT(
         return sendApiError(400, 'BAD_REQUEST', 'A criterion with this name already exists');
       }
       if (error.message.includes('criteria_event_id_display_order_key')) {
-        return sendApiError(400, 'BAD_REQUEST', 'A criterion with this display order already exists');
+        return sendApiError(
+          400,
+          'BAD_REQUEST',
+          'A criterion with this display order already exists'
+        );
       }
     }
 

--- a/app/api/admin/criteria/[criterionId]/route.ts
+++ b/app/api/admin/criteria/[criterionId]/route.ts
@@ -61,7 +61,13 @@ export async function PUT(
     }
 
     // Verify criterion's event belongs to org
-    await requireEventInOrg(currentCriterion.eventId, orgId);
+    try {
+      await requireEventInOrg(currentCriterion.eventId, orgId);
+    } catch (error: any) {
+      const status = error.status || error.statusCode || 403;
+      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
+      return sendApiError(status, code, error.message || 'Access to event denied');
+    }
 
     // Get all criteria in the same event to validate weight totals
     const allCriteria = await db
@@ -160,7 +166,13 @@ export async function DELETE(
       return sendApiError(404, 'NOT_FOUND', 'Criterion not found');
     }
 
-    await requireEventInOrg(existingCriterion.eventId, orgId);
+    try {
+      await requireEventInOrg(existingCriterion.eventId, orgId);
+    } catch (error: any) {
+      const status = error.status || error.statusCode || 403;
+      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
+      return sendApiError(status, code, error.message || 'Access to event denied');
+    }
 
     // Delete criterion (cascade will handle related scores)
     const [deletedCriterion] = await db

--- a/app/api/admin/criteria/reorder/route.ts
+++ b/app/api/admin/criteria/reorder/route.ts
@@ -21,13 +21,7 @@ export async function POST(request: NextRequest) {
       return sendApiError(400, 'BAD_REQUEST', 'Event ID is required');
     }
 
-    try {
-      await requireEventInOrg(eventId, orgId);
-    } catch (error: any) {
-      const status = error.status || error.statusCode || 403;
-      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
-      return sendApiError(status, code, error.message || 'Access to event denied');
-    }
+    await requireEventInOrg(eventId, orgId);
 
     if (!Array.isArray(criteriaOrders) || criteriaOrders.length === 0) {
       return sendApiError(400, 'BAD_REQUEST', 'Criteria orders array is required');

--- a/app/api/admin/criteria/reorder/route.ts
+++ b/app/api/admin/criteria/reorder/route.ts
@@ -30,7 +30,11 @@ export async function POST(request: NextRequest) {
     // Validate criteria orders structure
     for (const criteriaOrder of criteriaOrders) {
       if (!criteriaOrder.id || typeof criteriaOrder.displayOrder !== 'number') {
-        return sendApiError(400, 'BAD_REQUEST', 'Each criteria order must have id and displayOrder');
+        return sendApiError(
+          400,
+          'BAD_REQUEST',
+          'Each criteria order must have id and displayOrder'
+        );
       }
     }
 

--- a/app/api/admin/criteria/reorder/route.ts
+++ b/app/api/admin/criteria/reorder/route.ts
@@ -21,7 +21,13 @@ export async function POST(request: NextRequest) {
       return sendApiError(400, 'BAD_REQUEST', 'Event ID is required');
     }
 
-    await requireEventInOrg(eventId, orgId);
+    try {
+      await requireEventInOrg(eventId, orgId);
+    } catch (error: any) {
+      const status = error.status || error.statusCode || 403;
+      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
+      return sendApiError(status, code, error.message || 'Access to event denied');
+    }
 
     if (!Array.isArray(criteriaOrders) || criteriaOrders.length === 0) {
       return sendApiError(400, 'BAD_REQUEST', 'Criteria orders array is required');

--- a/app/api/admin/criteria/reorder/route.ts
+++ b/app/api/admin/criteria/reorder/route.ts
@@ -4,37 +4,33 @@ import { db } from '@/lib/db';
 import { criteria } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { getAdminOrgId, requireEventInOrg } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function POST(request: NextRequest) {
   try {
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
     const { eventId, criteriaOrders } = await request.json();
 
     if (!eventId) {
-      return NextResponse.json({ error: 'Event ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Event ID is required');
     }
 
     await requireEventInOrg(eventId, orgId);
 
     if (!Array.isArray(criteriaOrders) || criteriaOrders.length === 0) {
-      return NextResponse.json({ error: 'Criteria orders array is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Criteria orders array is required');
     }
 
     // Validate criteria orders structure
     for (const criteriaOrder of criteriaOrders) {
       if (!criteriaOrder.id || typeof criteriaOrder.displayOrder !== 'number') {
-        return NextResponse.json(
-          {
-            error: 'Each criteria order must have id and displayOrder',
-          },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'Each criteria order must have id and displayOrder');
       }
     }
 
@@ -65,7 +61,7 @@ export async function POST(request: NextRequest) {
 
     // Check if all updates were successful
     if (updatedCriteria.length !== criteriaOrders.length) {
-      return NextResponse.json({ error: 'Some criteria could not be updated' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Some criteria could not be updated');
     }
 
     return NextResponse.json({
@@ -78,15 +74,10 @@ export async function POST(request: NextRequest) {
     // Handle unique constraint violations
     if (error instanceof Error && error.message.includes('duplicate key')) {
       if (error.message.includes('criteria_event_id_display_order')) {
-        return NextResponse.json(
-          {
-            error: 'Duplicate display order detected',
-          },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'Duplicate display order detected');
       }
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/criteria/route.ts
+++ b/app/api/admin/criteria/route.ts
@@ -21,13 +21,7 @@ export async function GET(request: NextRequest) {
     // Build query with org-scoped conditions
     let allCriteria;
     if (eventId) {
-      try {
-        await requireEventInOrg(eventId, orgId);
-      } catch (error: any) {
-        const status = error.status || error.statusCode || 403;
-        const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
-        return sendApiError(status, code, error.message || 'Access to event denied');
-      }
+      await requireEventInOrg(eventId, orgId);
       allCriteria = await db
         .select()
         .from(criteria)
@@ -77,13 +71,7 @@ export async function POST(request: NextRequest) {
     }
 
     const orgId = await getAdminOrgId(user.id);
-    try {
-      await requireEventInOrg(eventId, orgId);
-    } catch (error: any) {
-      const status = error.status || error.statusCode || 403;
-      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
-      return sendApiError(status, code, error.message || 'Access to event denied');
-    }
+    await requireEventInOrg(eventId, orgId);
 
     if (!name || !name.trim()) {
       return sendApiError(400, 'BAD_REQUEST', 'Criteria name is required');

--- a/app/api/admin/criteria/route.ts
+++ b/app/api/admin/criteria/route.ts
@@ -21,7 +21,13 @@ export async function GET(request: NextRequest) {
     // Build query with org-scoped conditions
     let allCriteria;
     if (eventId) {
-      await requireEventInOrg(eventId, orgId);
+      try {
+        await requireEventInOrg(eventId, orgId);
+      } catch (error: any) {
+        const status = error.status || error.statusCode || 403;
+        const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
+        return sendApiError(status, code, error.message || 'Access to event denied');
+      }
       allCriteria = await db
         .select()
         .from(criteria)
@@ -71,7 +77,13 @@ export async function POST(request: NextRequest) {
     }
 
     const orgId = await getAdminOrgId(user.id);
-    await requireEventInOrg(eventId, orgId);
+    try {
+      await requireEventInOrg(eventId, orgId);
+    } catch (error: any) {
+      const status = error.status || error.statusCode || 403;
+      const code = status === 404 ? 'NOT_FOUND' : 'FORBIDDEN';
+      return sendApiError(status, code, error.message || 'Access to event denied');
+    }
 
     if (!name || !name.trim()) {
       return sendApiError(400, 'BAD_REQUEST', 'Criteria name is required');

--- a/app/api/admin/criteria/route.ts
+++ b/app/api/admin/criteria/route.ts
@@ -154,7 +154,11 @@ export async function POST(request: NextRequest) {
         return sendApiError(400, 'BAD_REQUEST', 'A criterion with this name already exists');
       }
       if (error.message.includes('criteria_event_id_display_order_key')) {
-        return sendApiError(400, 'BAD_REQUEST', 'A criterion with this display order already exists');
+        return sendApiError(
+          400,
+          'BAD_REQUEST',
+          'A criterion with this display order already exists'
+        );
       }
     }
 

--- a/app/api/admin/criteria/route.ts
+++ b/app/api/admin/criteria/route.ts
@@ -4,13 +4,14 @@ import { db } from '@/lib/db';
 import { criteria, events } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getAdminOrgId, requireEventInOrg } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET(request: NextRequest) {
   try {
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -50,7 +51,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ criteria: allCriteria });
   } catch (error) {
     console.error('Error fetching criteria:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -59,50 +60,44 @@ export async function POST(request: NextRequest) {
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const { eventId, name, description, minScore, maxScore, weight, category } =
       await request.json();
 
     if (!eventId) {
-      return NextResponse.json({ error: 'Event ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Event ID is required');
     }
 
     const orgId = await getAdminOrgId(user.id);
     await requireEventInOrg(eventId, orgId);
 
     if (!name || !name.trim()) {
-      return NextResponse.json({ error: 'Criteria name is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Criteria name is required');
     }
 
     if (typeof minScore !== 'number' || typeof maxScore !== 'number') {
-      return NextResponse.json({ error: 'Min and max scores must be numbers' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Min and max scores must be numbers');
     }
 
     if (minScore >= maxScore) {
-      return NextResponse.json({ error: 'Min score must be less than max score' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Min score must be less than max score');
     }
 
     if (typeof weight !== 'number' || weight < 0 || weight > 100) {
-      return NextResponse.json(
-        { error: 'Weight must be a number between 0 and 100' },
-        { status: 400 }
-      );
+      return sendApiError(400, 'BAD_REQUEST', 'Weight must be a number between 0 and 100');
     }
 
     if (!category || !['technical', 'business'].includes(category)) {
-      return NextResponse.json(
-        { error: 'Category must be either "technical" or "business"' },
-        { status: 400 }
-      );
+      return sendApiError(400, 'BAD_REQUEST', 'Category must be either "technical" or "business"');
     }
 
     // Verify event exists
     const event = await db.select().from(events).where(eq(events.id, eventId)).limit(1);
 
     if (event.length === 0) {
-      return NextResponse.json({ error: 'Event not found' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Event not found');
     }
 
     // Get existing criteria for weight validation and display order
@@ -127,11 +122,10 @@ export async function POST(request: NextRequest) {
 
     // Validate that the category weight total won't exceed 100%
     if (newWeightTotal > 100) {
-      return NextResponse.json(
-        {
-          error: `Cannot add criterion: ${category} category weights would total ${newWeightTotal}% (maximum 100%)`,
-        },
-        { status: 400 }
+      return sendApiError(
+        400,
+        'BAD_REQUEST',
+        `Cannot add criterion: ${category} category weights would total ${newWeightTotal}% (maximum 100%)`
       );
     }
 
@@ -157,19 +151,13 @@ export async function POST(request: NextRequest) {
     // Handle unique constraint violations
     if (error instanceof Error && error.message.includes('duplicate key')) {
       if (error.message.includes('criteria_event_id_name_key')) {
-        return NextResponse.json(
-          { error: 'A criterion with this name already exists' },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'A criterion with this name already exists');
       }
       if (error.message.includes('criteria_event_id_display_order_key')) {
-        return NextResponse.json(
-          { error: 'A criterion with this display order already exists' },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'A criterion with this display order already exists');
       }
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }


### PR DESCRIPTION
Implements part of #169

Description
---

This PR refactors the error handling in the Admin Criteria API routes to comply with FR-14: Basic Error Handling.

Changes
---
- Migrated from NextResponse.json() calls to the sendApiError utility.
- Replaced `NextResponse.json({ error: ... })` with `sendApiError(status, code, message)`.
  - The standardized error codes used are the following:
 
| Error Name | Status Code |
| :--- | :--- |
| `MULTIPLE_CHOICES` | 300 |
| `BAD_REQUEST` | 400 |
| `UNAUTHORIZED` | 401 |
| `FORBIDDEN` | 403 |
| `NOT_FOUND` | 404 |
| `CONFLICT` | 409 |
| `UNPROCESSABLE_ENTITY` | 422 |
| `INTERNAL_SERVER_ERROR` | 500 |

Updated routes:

1. `app/api/admin/criteria/route.ts`

2. `app/api/admin/criteria/reorder/route.ts`

3. `app/api/admin/criteria/[criterionId]/route.ts`