### PR TITLE
feat(MD-03): define LearnWorlds mentor auto-tag contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,18 @@ A comprehensive multi-tenant real-time judging platform for hackathons and compe
    npm run setup:email-template  # Requires SUPABASE_ACCESS_TOKEN
    ```
 
-6. **Start Development Server**
+6. **Configure LearnWorlds Mentor Auto-Tagging (MD-03)**
+   - Tag mentor form submissions with `role_mentor`
+   - Map Expertise answers to tags: `AgriTech` -> `mentor_agritech`, `Sustainability` -> `mentor_sustainability`, `AI` -> `mentor_ai`
+   - Mentor webhook payloads should include these values in `payload.tags`
+   - Canonical tag constants live in `lib/learnworlds/mentor-tags.ts`
+
+7. **Start Development Server**
    ```bash
    npm run dev
    ```
 
-7. **Open the Application**
+8. **Open the Application**
 
    Open [http://localhost:3000](http://localhost:3000) in your browser
 

--- a/lib/learnworlds/mentor-tags.ts
+++ b/lib/learnworlds/mentor-tags.ts
@@ -1,0 +1,57 @@
+/**
+ * Canonical LearnWorlds mentor tag contract for MD-03.
+ *
+ * LearnWorlds applies these tags when a user submits the mentor application
+ * form. The mentor webhook can use `role_mentor` to identify mentor applicants,
+ * and downstream mentor directory features can use the expertise tags stored in
+ * `mentor_profiles.tags` for filtering and display.
+ */
+export const LEARNWORLDS_MENTOR_ROLE_TAG = 'role_mentor' as const;
+
+export const LEARNWORLDS_MENTOR_EXPERTISE_TAGS = {
+  AgriTech: 'mentor_agritech',
+  Sustainability: 'mentor_sustainability',
+  AI: 'mentor_ai',
+} as const;
+
+export type LearnworldsMentorExpertise = keyof typeof LEARNWORLDS_MENTOR_EXPERTISE_TAGS;
+export type LearnworldsMentorExpertiseTag =
+  (typeof LEARNWORLDS_MENTOR_EXPERTISE_TAGS)[LearnworldsMentorExpertise];
+export type LearnworldsMentorTag =
+  | typeof LEARNWORLDS_MENTOR_ROLE_TAG
+  | LearnworldsMentorExpertiseTag;
+
+export const LEARNWORLDS_MENTOR_TAGS = [
+  LEARNWORLDS_MENTOR_ROLE_TAG,
+  ...Object.values(LEARNWORLDS_MENTOR_EXPERTISE_TAGS),
+] as const;
+
+const EXPERTISE_TAG_BY_NORMALIZED_LABEL = new Map<string, LearnworldsMentorExpertiseTag>(
+  Object.entries(LEARNWORLDS_MENTOR_EXPERTISE_TAGS).map(([label, tag]) => [
+    normalizeMentorExpertiseLabel(label),
+    tag,
+  ])
+);
+
+export function hasLearnworldsMentorRoleTag(tags: readonly string[] | null | undefined): boolean {
+  return tags?.includes(LEARNWORLDS_MENTOR_ROLE_TAG) ?? false;
+}
+
+export function getLearnworldsMentorExpertiseTag(
+  expertise: string
+): LearnworldsMentorExpertiseTag | null {
+  return EXPERTISE_TAG_BY_NORMALIZED_LABEL.get(normalizeMentorExpertiseLabel(expertise)) ?? null;
+}
+
+export function getLearnworldsMentorExpertiseTags(
+  expertiseAnswers: readonly string[]
+): LearnworldsMentorExpertiseTag[] {
+  return expertiseAnswers.flatMap((answer) => {
+    const tag = getLearnworldsMentorExpertiseTag(answer);
+    return tag ? [tag] : [];
+  });
+}
+
+function normalizeMentorExpertiseLabel(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/lib/learnworlds/mentor-tags.ts
+++ b/lib/learnworlds/mentor-tags.ts
@@ -46,10 +46,12 @@ export function getLearnworldsMentorExpertiseTag(
 export function getLearnworldsMentorExpertiseTags(
   expertiseAnswers: readonly string[]
 ): LearnworldsMentorExpertiseTag[] {
-  return expertiseAnswers.flatMap((answer) => {
+  const tags = expertiseAnswers.flatMap((answer) => {
     const tag = getLearnworldsMentorExpertiseTag(answer);
     return tag ? [tag] : [];
   });
+
+  return [...new Set(tags)];
 }
 
 function normalizeMentorExpertiseLabel(value: string): string {

--- a/tests/mentor-tags.spec.ts
+++ b/tests/mentor-tags.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import {
+  LEARNWORLDS_MENTOR_EXPERTISE_TAGS,
+  LEARNWORLDS_MENTOR_ROLE_TAG,
+  LEARNWORLDS_MENTOR_TAGS,
+  getLearnworldsMentorExpertiseTag,
+  getLearnworldsMentorExpertiseTags,
+  hasLearnworldsMentorRoleTag,
+} from '../lib/learnworlds/mentor-tags';
+
+test.describe('LearnWorlds mentor tag contract', () => {
+  test('defines the MD-03 role and expertise tags', () => {
+    expect(LEARNWORLDS_MENTOR_ROLE_TAG).toBe('role_mentor');
+    expect(LEARNWORLDS_MENTOR_EXPERTISE_TAGS).toEqual({
+      AgriTech: 'mentor_agritech',
+      Sustainability: 'mentor_sustainability',
+      AI: 'mentor_ai',
+    });
+    expect(LEARNWORLDS_MENTOR_TAGS).toEqual([
+      'role_mentor',
+      'mentor_agritech',
+      'mentor_sustainability',
+      'mentor_ai',
+    ]);
+  });
+
+  test('maps LearnWorlds expertise answers to mentor tags', () => {
+    expect(getLearnworldsMentorExpertiseTag('AgriTech')).toBe('mentor_agritech');
+    expect(getLearnworldsMentorExpertiseTag(' sustainability ')).toBe('mentor_sustainability');
+    expect(getLearnworldsMentorExpertiseTag('AI')).toBe('mentor_ai');
+    expect(getLearnworldsMentorExpertiseTag('Product Strategy')).toBeNull();
+  });
+
+  test('detects mentor role and filters unsupported expertise values', () => {
+    expect(hasLearnworldsMentorRoleTag(['learner', 'role_mentor'])).toBe(true);
+    expect(hasLearnworldsMentorRoleTag(['learner'])).toBe(false);
+    expect(hasLearnworldsMentorRoleTag(null)).toBe(false);
+
+    expect(getLearnworldsMentorExpertiseTags(['AI', 'Unknown', 'AgriTech'])).toEqual([
+      'mentor_ai',
+      'mentor_agritech',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #64

This PR defines the code-side contract and setup documentation for MD-03. The actual tag application is configured in LearnWorlds form settings, while this PR makes the expected tags explicit in the repo and verifies the Expertise-to-tag mapping.

## Changes

- Added canonical mentor tag constants for `role_mentor`, `mentor_agritech`, `mentor_sustainability`, and `mentor_ai`
- Added helper functions for checking mentor role tags and mapping Expertise answers to mentor expertise tags
- Added a short README setup note for LearnWorlds mentor form auto-tagging
- Added a small test covering the MD-03 tag contract

## Testing

- `npm run format:check -- README.md lib/learnworlds/mentor-tags.ts tests/mentor-tags.spec.ts`
- `npx tsc /Users/nevryks/Code/CS472/judge-portal/lib/learnworlds/mentor-tags.ts /Users/nevryks/Code/CS472/judge-portal/tests/mentor-tags.spec.ts --noEmit --pretty false --target ES2022 --module ESNext --moduleResolution Bundler --skipLibCheck`
- `npx playwright test tests/mentor-tags.spec.ts --project=chromium --reporter=line --output=/private/tmp/pw-md03-results`
