### PR TITLE
Refactor: Implement sendApiError in Admin Teams Routes

### DIFF
--- a/app/api/admin/teams/[teamId]/route.ts
+++ b/app/api/admin/teams/[teamId]/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db';
 import { teams } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getAdminOrgId, requireEventInOrg } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function PUT(
   request: NextRequest,
@@ -13,7 +14,7 @@ export async function PUT(
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -27,7 +28,7 @@ export async function PUT(
       .limit(1);
 
     if (!existingTeam) {
-      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Team not found');
     }
 
     await requireEventInOrg(existingTeam.eventId, orgId);
@@ -36,11 +37,11 @@ export async function PUT(
       await request.json();
 
     if (!name || !name.trim()) {
-      return NextResponse.json({ error: 'Team name is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Team name is required');
     }
 
     if (typeof presentationOrder !== 'number') {
-      return NextResponse.json({ error: 'Presentation order must be a number' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Presentation order must be a number');
     }
 
     // Update team (updatedAt is handled automatically by schema .$onUpdate)
@@ -58,7 +59,7 @@ export async function PUT(
       .returning();
 
     if (!team) {
-      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Team not found');
     }
 
     return NextResponse.json({ team });
@@ -68,20 +69,18 @@ export async function PUT(
     // Handle unique constraint violations
     if (error instanceof Error && error.message.includes('duplicate key')) {
       if (error.message.includes('teams_event_id_name_key')) {
-        return NextResponse.json(
-          { error: 'A team with this name already exists' },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'A team with this name already exists');
       }
       if (error.message.includes('teams_event_id_presentation_order_key')) {
-        return NextResponse.json(
-          { error: 'A team with this presentation order already exists' },
-          { status: 400 }
+        return sendApiError(
+          400,
+          'BAD_REQUEST',
+          'A team with this presentation order already exists'
         );
       }
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -93,7 +92,7 @@ export async function DELETE(
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -107,7 +106,7 @@ export async function DELETE(
       .limit(1);
 
     if (!existingTeam) {
-      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Team not found');
     }
 
     await requireEventInOrg(existingTeam.eventId, orgId);
@@ -116,12 +115,12 @@ export async function DELETE(
     const [deletedTeam] = await db.delete(teams).where(eq(teams.id, teamId)).returning();
 
     if (!deletedTeam) {
-      return NextResponse.json({ error: 'Team not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Team not found');
     }
 
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error deleting team:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/teams/reorder/route.ts
+++ b/app/api/admin/teams/reorder/route.ts
@@ -4,36 +4,36 @@ import { db } from '@/lib/db';
 import { teams } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { getAdminOrgId, requireEventInOrg } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function POST(request: NextRequest) {
   try {
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
     const { eventId, teamOrders } = await request.json();
 
     if (!eventId) {
-      return NextResponse.json({ error: 'Event ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Event ID is required');
     }
 
     await requireEventInOrg(eventId, orgId);
 
     if (!Array.isArray(teamOrders) || teamOrders.length === 0) {
-      return NextResponse.json({ error: 'Team orders array is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Team orders array is required');
     }
 
     // Validate team orders structure
     for (const teamOrder of teamOrders) {
       if (!teamOrder.id || typeof teamOrder.presentationOrder !== 'number') {
-        return NextResponse.json(
-          {
-            error: 'Each team order must have id and presentationOrder',
-          },
-          { status: 400 }
+        return sendApiError(
+          400,
+          'BAD_REQUEST',
+          'Each team order must have id and presentationOrder'
         );
       }
     }
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest) {
 
     // Check if all updates were successful
     if (updatedTeams.length !== teamOrders.length) {
-      return NextResponse.json({ error: 'Some teams could not be updated' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Some teams could not be updated');
     }
 
     return NextResponse.json({
@@ -78,15 +78,10 @@ export async function POST(request: NextRequest) {
     // Handle unique constraint violations
     if (error instanceof Error && error.message.includes('duplicate key')) {
       if (error.message.includes('teams_event_id_presentation_order')) {
-        return NextResponse.json(
-          {
-            error: 'Duplicate presentation order detected',
-          },
-          { status: 400 }
-        );
+        return sendApiError(400, 'BAD_REQUEST', 'Duplicate presentation order detected');
       }
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/teams/route.ts
+++ b/app/api/admin/teams/route.ts
@@ -5,13 +5,14 @@ import { teams, events, teamMembers, users } from '@/lib/db/schema';
 import { eq, max, inArray } from 'drizzle-orm';
 import { getAdminOrgId, requireEventInOrg } from '@/lib/auth/org';
 import { generateJoinCode } from '@/lib/utils/join-code';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET(request: NextRequest) {
   try {
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -81,7 +82,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ teams: teamsWithMembers });
   } catch (error) {
     console.error('Error fetching teams:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -90,18 +91,18 @@ export async function POST(request: NextRequest) {
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
     const { eventId, name, description, demoUrl, repoUrl, awardType } = await request.json();
 
     if (!eventId) {
-      return NextResponse.json({ error: 'Event ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Event ID is required');
     }
 
     if (!name || !name.trim()) {
-      return NextResponse.json({ error: 'Team name is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Team name is required');
     }
 
     // Verify event exists and belongs to org
@@ -109,7 +110,7 @@ export async function POST(request: NextRequest) {
     const event = await db.select().from(events).where(eq(events.id, eventId)).limit(1);
 
     if (event.length === 0) {
-      return NextResponse.json({ error: 'Event not found' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Event not found');
     }
 
     // Get the next presentation order by finding the max existing order
@@ -149,19 +150,17 @@ export async function POST(request: NextRequest) {
 
     if (errorMsg.includes('duplicate key')) {
       if (errorMsg.includes('teams_event_id_name_key')) {
-        return NextResponse.json(
-          { error: 'A team with this name already exists in this event' },
-          { status: 400 }
-        );
+        sendApiError(400, 'BAD_REQUEST', 'A team with this name already exists in this event');
       }
       if (errorMsg.includes('teams_event_id_presentation_order_key')) {
-        return NextResponse.json(
-          { error: 'A team with this presentation order already exists' },
-          { status: 400 }
+        return sendApiError(
+          400,
+          'BAD_REQUEST',
+          'A team with this presentation order already exists'
         );
       }
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }


### PR DESCRIPTION
Implements part of #169

Description
---

This PR refactors the error handling in the `admin/teams` API routes to comply with FR-14: Basic Error Handling.

Changes
---
- Migrated from NextResponse.json() calls to the sendApiError utility.
- Replaced `NextResponse.json({ error: ... })` with `sendApiError(status, code, message)`.
  - The standardized error codes used are the following:
 
| Error Name | Status Code |
| :--- | :--- |
| `MULTIPLE_CHOICES` | 300 |
| `BAD_REQUEST` | 400 |
| `UNAUTHORIZED` | 401 |
| `FORBIDDEN` | 403 |
| `NOT_FOUND` | 404 |
| `CONFLICT` | 409 |
| `UNPROCESSABLE_ENTITY` | 422 |
| `INTERNAL_SERVER_ERROR` | 500 |

Updated routes:

1. `app/api/admin/teams/[teamId]/route.ts`
2. `app/api/admin/teams/reorder/route.ts`
3. `app/api/admin/teams/route.ts`