### PR TITLE
Refactor: Implement sendApiError in Admin Invitations and Users Routes

### DIFF
--- a/app/api/admin/invitations/[id]/route.ts
+++ b/app/api/admin/invitations/[id]/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db';
 import { invitations } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { getAdminOrgId } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 /**
  * PATCH /api/admin/invitations/[id]
@@ -18,21 +19,18 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     const { id } = await params;
 
     if (!id) {
-      return NextResponse.json({ error: 'Invitation ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Invitation ID is required');
     }
 
     // Verify invitation belongs to org
     const [invitation] = await db.select().from(invitations).where(eq(invitations.id, id)).limit(1);
 
     if (!invitation) {
-      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Invitation not found');
     }
 
     if (invitation.organizationId !== orgId) {
-      return NextResponse.json(
-        { error: 'Invitation does not belong to your organization' },
-        { status: 403 }
-      );
+      return sendApiError(403, 'FORBIDDEN', 'Invitation does not belong to your organization');
     }
 
     // Revoke invitation
@@ -46,10 +44,10 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     console.error('Revoke invitation error:', error);
 
     if (error instanceof Error && error.message?.includes('role required')) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Admin access required');
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -69,21 +67,18 @@ export async function DELETE(
     const { id } = await params;
 
     if (!id) {
-      return NextResponse.json({ error: 'Invitation ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Invitation ID is required');
     }
 
     // Verify invitation belongs to org
     const [invitation] = await db.select().from(invitations).where(eq(invitations.id, id)).limit(1);
 
     if (!invitation) {
-      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Invitation not found');
     }
 
     if (invitation.organizationId !== orgId) {
-      return NextResponse.json(
-        { error: 'Invitation does not belong to your organization' },
-        { status: 403 }
-      );
+      return sendApiError(403, 'FORBIDDEN', 'Invitation does not belong to your organization');
     }
 
     // Delete invitation
@@ -97,9 +92,9 @@ export async function DELETE(
     console.error('Delete invitation error:', error);
 
     if (error instanceof Error && error.message?.includes('role required')) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Admin access required');
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/invitations/route.ts
+++ b/app/api/admin/invitations/route.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db';
 import { users, invitations, organizationMembers } from '@/lib/db/schema';
 import { eq, and, desc } from 'drizzle-orm';
 import { getAdminOrgId } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 /**
  * POST /api/admin/invitations
@@ -22,22 +23,19 @@ export async function POST(request: NextRequest) {
     // Validate role
     const validRoles = ['admin', 'judge', 'participant'];
     if (!validRoles.includes(role)) {
-      return NextResponse.json({ error: 'Invalid role' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Invalid role');
     }
 
     // Validation
     if (!emails || !Array.isArray(emails) || emails.length === 0) {
-      return NextResponse.json({ error: 'At least one email is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'At least one email is required');
     }
 
     // Validate email format
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     const invalidEmails = emails.filter((email: string) => !emailRegex.test(email));
     if (invalidEmails.length > 0) {
-      return NextResponse.json(
-        { error: 'Invalid email addresses', invalidEmails },
-        { status: 400 }
-      );
+      return sendApiError(400, 'BAD_REQUEST', 'Invalid email addresses');
     }
 
     // Check for existing pending invitations
@@ -164,10 +162,10 @@ export async function POST(request: NextRequest) {
     console.error('Create invitations error:', error);
 
     if (error instanceof Error && error.message?.includes('role required')) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Admin access required');
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -210,9 +208,9 @@ export async function GET(request: NextRequest) {
     console.error('List invitations error:', error);
 
     if (error instanceof Error && error.message?.includes('role required')) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Admin access required');
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/users/[userId]/role/route.ts
+++ b/app/api/admin/users/[userId]/role/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db';
 import { users, organizationMembers } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { getAdminOrgId } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function PUT(
   request: NextRequest,
@@ -14,36 +15,31 @@ export async function PUT(
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const adminOrgId = await getAdminOrgId(user.id);
     const { role } = await request.json();
 
     if (!role || !['admin', 'judge', 'participant'].includes(role)) {
-      return NextResponse.json({ error: 'Invalid role' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Invalid role');
     }
 
     // Block promotion to super_admin
     if (role === 'super_admin') {
-      return NextResponse.json({ error: 'Cannot promote to super_admin' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Cannot promote to super_admin');
     }
 
     // Prevent admin from demoting themselves
     if (userId === user.id && role !== 'admin') {
-      return NextResponse.json(
-        {
-          error: 'Cannot change your own admin role',
-        },
-        { status: 400 }
-      );
+      return sendApiError(400, 'BAD_REQUEST', 'Cannot change your own admin role');
     }
 
     // Fetch current user to check current role
     const [currentTargetUser] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
 
     if (!currentTargetUser) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'User not found');
     }
 
     // Build update data with org assignment logic
@@ -87,12 +83,12 @@ export async function PUT(
       .returning();
 
     if (!updatedUser) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'User not found');
     }
 
     return NextResponse.json({ user: updatedUser });
   } catch (error) {
     console.error('Error updating user role:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/users/[userId]/route.ts
+++ b/app/api/admin/users/[userId]/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/db/schema';
 import { eq, and, inArray, sql } from 'drizzle-orm';
 import { getAdminOrgId } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function DELETE(
   _request: NextRequest,
@@ -21,7 +22,7 @@ export async function DELETE(
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -31,20 +32,17 @@ export async function DELETE(
     const [targetUser] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
 
     if (!targetUser) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'User not found');
     }
 
     // Prevent deletion of super_admin users
     if (targetUser.role === 'super_admin') {
-      return NextResponse.json({ error: 'Cannot delete super admin users' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Cannot delete super admin users');
     }
 
     // Prevent deletion of admins from other organizations
     if (targetUser.role === 'admin' && targetUser.organizationId !== orgId) {
-      return NextResponse.json(
-        { error: 'Cannot delete admins from other organizations' },
-        { status: 403 }
-      );
+      return sendApiError(403, 'FORBIDDEN', 'Cannot delete admins from other organizations');
     }
 
     // Judge removal: ALWAYS remove from org only, never delete user record
@@ -56,10 +54,7 @@ export async function DELETE(
 
       const isInAdminOrg = memberships.some((m) => m.organizationId === orgId);
       if (!isInAdminOrg) {
-        return NextResponse.json(
-          { error: 'This judge is not a member of your organization' },
-          { status: 403 }
-        );
+        return sendApiError(403, 'FORBIDDEN', 'This judge is not a member of your organization');
       }
 
       // Remove org membership
@@ -111,9 +106,10 @@ export async function DELETE(
         .limit(1);
 
       if (participantInOrg.length === 0) {
-        return NextResponse.json(
-          { error: 'This participant is not associated with your organization' },
-          { status: 403 }
+        return sendApiError(
+          403,
+          'FORBIDDEN',
+          'This participant is not associated with your organization'
         );
       }
     }
@@ -124,7 +120,7 @@ export async function DELETE(
       await db.delete(users).where(eq(users.id, userId));
     } catch (dbError) {
       console.error('Failed to delete user from database:', userId, dbError);
-      return NextResponse.json({ error: 'Failed to delete user' }, { status: 500 });
+      return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Failed to delete user');
     }
 
     // Then delete from Supabase Auth
@@ -137,6 +133,6 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error deleting user:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -11,13 +11,14 @@ import {
 } from '@/lib/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 import { getAdminOrgId } from '@/lib/auth/org';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET() {
   try {
     const user = await getUserFromSession();
 
     if (!user || user.role !== 'admin') {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
 
     const orgId = await getAdminOrgId(user.id);
@@ -82,6 +83,6 @@ export async function GET() {
     return NextResponse.json({ users: allUsers });
   } catch (error) {
     console.error('Error fetching users:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }


### PR DESCRIPTION
Implements part of #169

Description
---

This PR refactors the error handling in the `admin/invitations` and `admin/users` API routes to comply with FR-14: Basic Error Handling.

Changes
---
- Migrated from NextResponse.json() calls to the sendApiError utility.
- Replaced `NextResponse.json({ error: ... })` with `sendApiError(status, code, message)`.
  - The standardized error codes used are the following:
 
| Error Name | Status Code |
| :--- | :--- |
| `MULTIPLE_CHOICES` | 300 |
| `BAD_REQUEST` | 400 |
| `UNAUTHORIZED` | 401 |
| `FORBIDDEN` | 403 |
| `NOT_FOUND` | 404 |
| `CONFLICT` | 409 |
| `UNPROCESSABLE_ENTITY` | 422 |
| `INTERNAL_SERVER_ERROR` | 500 |

Updated routes:

1. `app/api/admin/invitations/[id]/route.ts`
2. `app/api/admin/invitations/route.ts`
3. `app/api/admin/users/[userId]/role/route.ts`
4. `app/api/admin/users/[userId]/route.ts`
5. `app/api/admin/users/route.ts`