### PR TITLE
Refactor: Implement sendApiError in Super Admin Routes

### DIFF
--- a/app/api/super-admin/organizations/[orgId]/admins/route.ts
+++ b/app/api/super-admin/organizations/[orgId]/admins/route.ts
@@ -8,6 +8,7 @@ import {
   calculateExpirationDate,
   getExistingInvitation,
 } from '@/lib/auth/invitation';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET(request: Request, { params }: { params: Promise<{ orgId: string }> }) {
   try {
@@ -22,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ orgI
       .limit(1);
 
     if (!org) {
-      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Organization not found');
     }
 
     const admins = await db
@@ -39,10 +40,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ orgI
     return NextResponse.json({ admins });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error fetching org admins:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 

--- a/app/api/super-admin/organizations/[orgId]/admins/route.ts
+++ b/app/api/super-admin/organizations/[orgId]/admins/route.ts
@@ -60,14 +60,14 @@ export async function POST(request: Request, { params }: { params: Promise<{ org
       .limit(1);
 
     if (!org) {
-      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Organization not found');
     }
 
     const body = await request.json();
     const { emails, customMessage, expiresInDays = 7 } = body;
 
     if (!emails || !Array.isArray(emails) || emails.length === 0) {
-      return NextResponse.json({ error: 'At least one email is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'At least one email is required');
     }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -151,9 +151,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ org
     });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
     console.error('Error inviting admin:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/super-admin/organizations/[orgId]/invitations/route.ts
+++ b/app/api/super-admin/organizations/[orgId]/invitations/route.ts
@@ -3,6 +3,7 @@ import { authServer } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { organizations, invitations } from '@/lib/db/schema';
 import { eq, and, desc } from 'drizzle-orm';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET(request: Request, { params }: { params: Promise<{ orgId: string }> }) {
   try {
@@ -17,7 +18,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ orgI
       .limit(1);
 
     if (!org) {
-      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Organization not found');
     }
 
     const orgInvitations = await db
@@ -40,10 +41,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ orgI
     return NextResponse.json({ invitations: invitesWithLinks });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error fetching org invitations:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -54,7 +55,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ or
     const { invitationId } = await request.json();
 
     if (!invitationId) {
-      return NextResponse.json({ error: 'Invitation ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Invitation ID is required');
     }
 
     // Verify invitation belongs to this org
@@ -65,7 +66,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ or
       .limit(1);
 
     if (!invite) {
-      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Invitation not found');
     }
 
     await db
@@ -76,10 +77,10 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ or
     return NextResponse.json({ success: true, message: 'Invitation revoked' });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error revoking invitation:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -90,7 +91,7 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ o
     const { invitationId } = await request.json();
 
     if (!invitationId) {
-      return NextResponse.json({ error: 'Invitation ID is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Invitation ID is required');
     }
 
     // Verify invitation belongs to this org
@@ -101,7 +102,7 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ o
       .limit(1);
 
     if (!invite) {
-      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Invitation not found');
     }
 
     await db.delete(invitations).where(eq(invitations.id, invitationId));

--- a/app/api/super-admin/organizations/[orgId]/invitations/route.ts
+++ b/app/api/super-admin/organizations/[orgId]/invitations/route.ts
@@ -110,9 +110,9 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ o
     return NextResponse.json({ success: true, message: 'Invitation deleted' });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(401, 'UNAUTHORIZED', 'Unauthorized');
     }
     console.error('Error deleting invitation:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/super-admin/organizations/[orgId]/route.ts
+++ b/app/api/super-admin/organizations/[orgId]/route.ts
@@ -3,6 +3,7 @@ import { authServer } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { organizations, users, events } from '@/lib/db/schema';
 import { eq, and, ne, count } from 'drizzle-orm';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET(request: Request, { params }: { params: Promise<{ orgId: string }> }) {
   try {
@@ -12,7 +13,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ orgI
     const [org] = await db.select().from(organizations).where(eq(organizations.id, orgId)).limit(1);
 
     if (!org) {
-      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Organization not found');
     }
 
     // Get counts separately for reliability
@@ -35,10 +36,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ orgI
     });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error fetching organization:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -56,14 +57,14 @@ export async function PUT(request: Request, { params }: { params: Promise<{ orgI
       .limit(1);
 
     if (!existing) {
-      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Organization not found');
     }
 
     // Build update values
     const updateValues: Record<string, unknown> = {};
     if (name !== undefined) {
       if (!name.trim()) {
-        return NextResponse.json({ error: 'Organization name cannot be empty' }, { status: 400 });
+        return sendApiError(400, 'BAD_REQUEST', 'Organization name cannot be empty');
       }
       updateValues.name = name.trim();
     }
@@ -73,7 +74,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ orgI
         .toLowerCase()
         .replace(/[^a-z0-9-]/g, '-');
       if (!slugValue) {
-        return NextResponse.json({ error: 'Organization slug cannot be empty' }, { status: 400 });
+        return sendApiError(400, 'BAD_REQUEST', 'Organization slug cannot be empty');
       }
       // Check slug uniqueness (excluding self)
       const slugConflict = await db
@@ -83,10 +84,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ orgI
         .limit(1);
 
       if (slugConflict.length > 0) {
-        return NextResponse.json(
-          { error: 'An organization with this slug already exists' },
-          { status: 409 }
-        );
+        return sendApiError(409, 'CONFLICT', 'An organization with this slug already exists');
       }
       updateValues.slug = slugValue;
     }
@@ -94,7 +92,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ orgI
     if (logoUrl !== undefined) updateValues.logoUrl = logoUrl?.trim() || null;
 
     if (Object.keys(updateValues).length === 0) {
-      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'No fields to update');
     }
 
     const [updated] = await db
@@ -106,10 +104,10 @@ export async function PUT(request: Request, { params }: { params: Promise<{ orgI
     return NextResponse.json({ organization: updated });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error updating organization:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -126,7 +124,7 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ o
       .limit(1);
 
     if (!existing) {
-      return NextResponse.json({ error: 'Organization not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'Organization not found');
     }
 
     // Delete org (cascades to events via FK)
@@ -135,9 +133,9 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ o
     return NextResponse.json({ success: true, message: `Organization "${existing.name}" deleted` });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error deleting organization:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/super-admin/organizations/route.ts
+++ b/app/api/super-admin/organizations/route.ts
@@ -3,6 +3,7 @@ import { authServer } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { organizations, users, events } from '@/lib/db/schema';
 import { eq, and, count } from 'drizzle-orm';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET() {
   try {
@@ -40,10 +41,10 @@ export async function GET() {
     return NextResponse.json({ organizations: orgsWithStats });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error fetching organizations:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }
 
@@ -54,11 +55,11 @@ export async function POST(request: Request) {
     const { name, slug, description, logoUrl } = await request.json();
 
     if (!name || !name.trim()) {
-      return NextResponse.json({ error: 'Organization name is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Organization name is required');
     }
 
     if (!slug || !slug.trim()) {
-      return NextResponse.json({ error: 'Organization slug is required' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Organization slug is required');
     }
 
     const slugValue = slug
@@ -74,10 +75,7 @@ export async function POST(request: Request) {
       .limit(1);
 
     if (existing.length > 0) {
-      return NextResponse.json(
-        { error: 'An organization with this slug already exists' },
-        { status: 409 }
-      );
+      return sendApiError(409, 'CONFLICT', 'An organization with this slug already exists');
     }
 
     const [org] = await db
@@ -96,9 +94,9 @@ export async function POST(request: Request) {
     );
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error creating organization:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/super-admin/users/[userId]/role/route.ts
+++ b/app/api/super-admin/users/[userId]/role/route.ts
@@ -11,6 +11,7 @@ import {
   scores,
 } from '@/lib/db/schema';
 import { eq, and, sql, asc } from 'drizzle-orm';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 const VALID_ROLES = ['admin', 'judge', 'participant'] as const;
 
@@ -21,15 +22,16 @@ export async function PUT(request: Request, { params }: { params: Promise<{ user
     const { role, organizationId } = await request.json();
 
     if (!role || !VALID_ROLES.includes(role)) {
-      return NextResponse.json(
-        { error: `Invalid role. Must be one of: ${VALID_ROLES.join(', ')}` },
-        { status: 400 }
+      return sendApiError(
+        400,
+        'BAD_REQUEST',
+        `Invalid role. Must be one of: ${VALID_ROLES.join(', ')}`
       );
     }
 
     // Cannot change own role
     if (userId === currentUser.id) {
-      return NextResponse.json({ error: 'Cannot change your own role' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Cannot change your own role');
     }
 
     // Verify user exists
@@ -40,20 +42,17 @@ export async function PUT(request: Request, { params }: { params: Promise<{ user
       .limit(1);
 
     if (!targetUser) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'User not found');
     }
 
     // Cannot change another super_admin's role
     if (targetUser.role === 'super_admin') {
-      return NextResponse.json({ error: 'Cannot change super admin role' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Cannot change super admin role');
     }
 
     // When promoting to admin, organizationId is required
     if (role === 'admin' && !organizationId) {
-      return NextResponse.json(
-        { error: 'Organization is required when assigning admin role' },
-        { status: 400 }
-      );
+      return sendApiError(400, 'BAD_REQUEST', 'Organization is required when assigning admin role');
     }
 
     // Set organizationId: use provided value for admin, null for others
@@ -173,9 +172,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ user
     return NextResponse.json({ user: updatedUser });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error updating user role:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/super-admin/users/[userId]/route.ts
+++ b/app/api/super-admin/users/[userId]/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { createAdminClient } from '@/lib/supabase/server';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function DELETE(
   request: Request,
@@ -15,7 +16,7 @@ export async function DELETE(
 
     // Cannot delete yourself
     if (userId === currentUser.id) {
-      return NextResponse.json({ error: 'Cannot delete your own account' }, { status: 400 });
+      return sendApiError(400, 'BAD_REQUEST', 'Cannot delete your own account');
     }
 
     // Verify user exists
@@ -26,12 +27,12 @@ export async function DELETE(
       .limit(1);
 
     if (!targetUser) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+      return sendApiError(404, 'NOT_FOUND', 'User not found');
     }
 
     // Prevent deletion of other super_admins
     if (targetUser.role === 'super_admin') {
-      return NextResponse.json({ error: 'Cannot delete super admin users' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Cannot delete super admin users');
     }
 
     // Delete from database FIRST (removes FK reference to auth.users)
@@ -39,7 +40,7 @@ export async function DELETE(
       await db.delete(users).where(eq(users.id, userId));
     } catch (dbError) {
       console.error('Failed to delete user from database:', userId, dbError);
-      return NextResponse.json({ error: 'Failed to delete user' }, { status: 500 });
+      return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Failed to delete user');
     }
 
     // Then delete from Supabase Auth
@@ -52,9 +53,9 @@ export async function DELETE(
     return NextResponse.json({ success: true, message: `User "${targetUser.email}" deleted` });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error deleting user:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }

--- a/app/api/super-admin/users/route.ts
+++ b/app/api/super-admin/users/route.ts
@@ -3,6 +3,7 @@ import { authServer } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { users, organizations, organizationMembers } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
+import { sendApiError } from '@/lib/utils/api-errors';
 
 export async function GET() {
   try {
@@ -49,9 +50,9 @@ export async function GET() {
     return NextResponse.json({ users: usersWithMemberships });
   } catch (error) {
     if (error instanceof Error && error.message.includes('required')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+      return sendApiError(403, 'FORBIDDEN', 'Unauthorized');
     }
     console.error('Error fetching users:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return sendApiError(500, 'INTERNAL_SERVER_ERROR', 'Internal server error');
   }
 }


### PR DESCRIPTION
Implements part of #169

Description
---

This PR refactors the error handling in the `super-admin/organizations` and `super-admin/users` API routes to comply with FR-14: Basic Error Handling.

Changes
---
- Migrated from NextResponse.json() calls to the sendApiError utility.
- Replaced `NextResponse.json({ error: ... })` with `sendApiError(status, code, message)`.
  - The standardized error codes used are the following:
 
| Error Name | Status Code |
| :--- | :--- |
| `MULTIPLE_CHOICES` | 300 |
| `BAD_REQUEST` | 400 |
| `UNAUTHORIZED` | 401 |
| `FORBIDDEN` | 403 |
| `NOT_FOUND` | 404 |
| `CONFLICT` | 409 |
| `UNPROCESSABLE_ENTITY` | 422 |
| `INTERNAL_SERVER_ERROR` | 500 |

Updated routes:

1. `app/api/super-admin/organizations/[orgId]/admins/route.ts`
2. `app/api/super-admin/organizations/[orgId]/invitations/route.ts`
3. `app/api/super-admin/organizations/[orgId]/route.ts`
4. `app/api/super-admin/organizations/route.ts`
5. `app/api/super-admin/users/[userId]/role/route.ts`
6. `app/api/super-admin/users/[userId]/route.ts`
7. `app/api/super-admin/users/route.ts`