### PR TITLE
FR-4 Polish and finishing touches

### DIFF
--- a/AI/BGE_M3.py
+++ b/AI/BGE_M3.py
@@ -106,13 +106,13 @@ class AISubmissionScreening:
             org_id: The organization ID that must own the event
             
         Returns:
-            List of criteria dictionaries
+            Event metadata and list of criteria dictionaries
             
         Raises:
             ValueError: If no criteria found or event does not belong to the organization
         """
         event_response = self.supabase.table("events") \
-            .select("id") \
+            .select("id, name, description") \
             .eq("id", event_id) \
             .eq("organization_id", org_id) \
             .limit(1) \
@@ -120,6 +120,8 @@ class AISubmissionScreening:
 
         if not event_response.data:
             raise ValueError(f"No event found for event {event_id} in organization {org_id}")
+
+        event = event_response.data[0]
 
         response = self.supabase.table("criteria") \
             .select("id, name, description, min_score, max_score, weight, category") \
@@ -130,7 +132,10 @@ class AISubmissionScreening:
         if not response.data:
             print(f"Warning: No criteria found for event {event_id} in organization {org_id}")
         
-        return response.data
+        return {
+            "event": event,
+            "criteria": response.data
+        }
 
     # score a submission, calc final score, and normalize
     def scoreSubmission(self, event_id: str, org_id: str, submission_text: str):
@@ -148,13 +153,32 @@ class AISubmissionScreening:
         Raises:
             ValueError: If event does not belong to the organization or no criteria found
         """
-        criteria = self.fetchChallengeCriteria(event_id, org_id)
+        challenge = self.fetchChallengeCriteria(event_id, org_id)
+        event = challenge["event"]
+        criteria = challenge["criteria"]
+
+        event_context_parts = []
+        event_name = (event.get("name") or "").strip()
+        event_description = (event.get("description") or "").strip()
+
+        if event_name:
+            event_context_parts.append(f"Event name: {event_name}")
+        if event_description:
+            event_context_parts.append(f"Event description: {event_description}")
+
+        event_context = "\n".join(event_context_parts)
         
         results = []
 
         for c in criteria:
             # criterion embedding
-            criterionText = f"{c['name']}: {c['description']}"
+            criterion_parts = []
+            if event_context:
+                criterion_parts.append(event_context)
+            criterion_parts.append(f"Criterion: {c['name']}")
+            if c.get("description"):
+                criterion_parts.append(f"Criterion description: {c['description']}")
+            criterionText = "\n".join(criterion_parts)
             criterionEmbedding = self.getEmbedding(criterionText)
             
             # compute similarity b/w criteria and submission

--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getUserFromSession } from '@/lib/auth/server';
 import { db } from '@/lib/db';
-import { events, submissions, teamMembers, teams } from '@/lib/db/schema';
+import { events, submissionAiScores, submissions, teamMembers, teams } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { sendApiError } from '@/lib/utils/api-errors';
 
@@ -35,6 +35,7 @@ export async function POST(req: Request) {
       .select({
         eventId: teams.eventId,
         organizationId: events.organizationId,
+        eventStatus: events.status,
       })
       .from(teams)
       .innerJoin(events, eq(teams.eventId, events.id))
@@ -47,29 +48,40 @@ export async function POST(req: Request) {
 
     const eventId = teamRecord[0].eventId;
     const organizationId = teamRecord[0].organizationId;
+    const eventStatus = teamRecord[0].eventStatus;
+
+    if (eventStatus !== 'open') {
+      return sendApiError(
+        400,
+        'EVENT_NOT_OPEN',
+        'Submissions are only accepted while the event is open'
+      );
+    }
 
     const existing = await db
-      .select()
+      .select({ id: submissions.id })
       .from(submissions)
       .where(and(eq(submissions.teamId, teamId), eq(submissions.eventId, eventId)))
       .limit(1);
 
-    if (existing.length > 0) {
-      return sendApiError(
-        400,
-        'SUBMISSION_ALREADY_EXISTS',
-        'Submission already exists for this team'
-      );
-    }
+    const [inserted] = await db.transaction(async (tx) => {
+      if (existing.length > 0) {
+        await tx
+          .delete(submissionAiScores)
+          .where(eq(submissionAiScores.submissionId, existing[0].id));
 
-    const [inserted] = await db
-      .insert(submissions)
-      .values({
-        eventId,
-        teamId,
-        submissionText: normalizedSubmissionText,
-      })
-      .returning({ id: submissions.id });
+        await tx.delete(submissions).where(eq(submissions.id, existing[0].id));
+      }
+
+      return tx
+        .insert(submissions)
+        .values({
+          eventId,
+          teamId,
+          submissionText: normalizedSubmissionText,
+        })
+        .returning({ id: submissions.id });
+    });
 
     try {
       const scoringUrl = process.env.AI_SCORING_URL ?? 'http://127.0.0.1:8000/score';

--- a/app/participant/components/create-team-dialog.tsx
+++ b/app/participant/components/create-team-dialog.tsx
@@ -173,10 +173,10 @@ export function CreateTeamDialog({
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="team-description">Description (optional)</Label>
+                <Label htmlFor="team-description">About (optional)</Label>
                 <Textarea
                   id="team-description"
-                  placeholder="Describe your project idea..."
+                  placeholder="Tell us about your team..."
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   rows={3}

--- a/app/participant/components/team-detail-panel.tsx
+++ b/app/participant/components/team-detail-panel.tsx
@@ -152,7 +152,8 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
   }, [editName, editDescription, editDemoUrl, editRepoUrl, team]);
 
   const isLocked = team?.eventStatus === 'active';
-  const canSubmit = team?.eventStatus === 'open' && !team?.hasSubmitted;
+  const isResubmission = team?.eventStatus === 'open' && team?.hasSubmitted;
+  const canSubmit = team?.eventStatus === 'open';
 
   const handleSave = async () => {
     if (!team || !hasChanges) return;
@@ -250,7 +251,7 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
 
   const handleSubmit = async () => {
     if (!submissionText.trim()) {
-      toast.error('Submission cannot be empty');
+      toast.error('Proposal cannot be empty');
       return;
     }
 
@@ -274,7 +275,9 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
         throw new Error(data.error_message || 'Submission failed');
       }
 
-      toast.success('Project submitted successfully!');
+      toast.success(
+        isResubmission ? 'Proposal resubmitted successfully!' : 'Proposal submitted successfully!'
+      );
       setShowSubmit(false);
       setSubmissionText('');
       await fetchTeam();
@@ -350,32 +353,6 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
             )}
           </div>
 
-          {/* Submission Button */}
-          <div className="flex items-center justify-center flex-1">
-            <div className="relative">
-              <Button
-                onClick={() => setShowSubmit(true)}
-                disabled={!canSubmit}
-                className={`
-                  ${
-                    canSubmit
-                      ? 'bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 text-white shadow-md'
-                      : 'bg-muted text-muted-foreground cursor-not-allowed opacity-60'
-                  }
-                `}
-              >
-                {team?.hasSubmitted ? (
-                  <>
-                    <CheckCircle2 className="h-4 w-4 mr-2" />
-                    Submitted
-                  </>
-                ) : (
-                  'Submit'
-                )}
-              </Button>
-            </div>
-          </div>
-
           {/* Stats */}
           <div className="flex items-center justify-end flex-1 gap-4 sm:gap-6">
             <div className="text-center">
@@ -428,6 +405,42 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
                 />
               </Button>
             )}
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-xl border border-border/50 bg-muted/30 p-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">Submit Proposal</h3>
+              <p className="text-sm text-muted-foreground">
+                Each team must submit one proposal before the event due date. Keep it concise and
+                explain the problem, your solution, working features, business value, scalability,
+                and technical implementation. Demo and repository URLs are also required in Team
+                Details before the event due date.
+              </p>
+            </div>
+            <Button
+              onClick={() => setShowSubmit(true)}
+              disabled={!canSubmit}
+              className={`w-full sm:w-auto sm:flex-shrink-0 ${
+                isResubmission
+                  ? 'bg-destructive hover:bg-destructive/90 text-destructive-foreground shadow-md'
+                  : canSubmit
+                    ? 'bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 text-white shadow-md'
+                    : 'bg-muted text-muted-foreground cursor-not-allowed opacity-60'
+              }`}
+            >
+              {isResubmission ? (
+                'Resubmit'
+              ) : team?.hasSubmitted ? (
+                <>
+                  <CheckCircle2 className="h-4 w-4 mr-2" />
+                  Proposal Submitted
+                </>
+              ) : (
+                'Submit'
+              )}
+            </Button>
           </div>
         </div>
       </Card>
@@ -503,14 +516,14 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="edit-description">Description</Label>
+            <Label htmlFor="edit-description">About</Label>
             <Textarea
               id="edit-description"
               value={editDescription}
               onChange={(e) => setEditDescription(e.target.value)}
               disabled={isLocked}
               rows={3}
-              placeholder="Describe your project..."
+              placeholder="Tell us about your team..."
               maxLength={500}
             />
           </div>
@@ -568,14 +581,15 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
       <Dialog open={showSubmit} onOpenChange={setShowSubmit}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Submit Project</DialogTitle>
+            <DialogTitle>Submit Proposal</DialogTitle>
           </DialogHeader>
 
           <div className="space-y-3">
             <Textarea
-              placeholder="Describe Your Solution..."
+              placeholder="Describe your proposal..."
               value={submissionText}
               onChange={(e) => setSubmissionText(e.target.value)}
+              rows={8}
             />
           </div>
 
@@ -587,9 +601,13 @@ export function TeamDetailPanel({ teamId }: TeamDetailPanelProps) {
             <Button
               onClick={handleSubmit}
               disabled={isSubmitting}
-              className="bg-teal-600 hover:bg-teal-700 text-white"
+              className={
+                isResubmission
+                  ? 'bg-destructive hover:bg-destructive/90 text-destructive-foreground'
+                  : 'bg-teal-600 hover:bg-teal-700 text-white'
+              }
             >
-              {isSubmitting ? 'Submitting...' : 'Submit'}
+              {isSubmitting ? 'Submitting...' : isResubmission ? 'Resubmit' : 'Submit'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ def score(req: SubmissionRequest):
         if not req.content.strip():
             score = 0.0
         else:
-            score = score_submission(submission_event_id, req.org_id, req.content)
+            score = round(score_submission(submission_event_id, req.org_id, req.content), 2)
 
         supabase.table("submission_ai_scores") \
             .upsert({

--- a/tests/mentor-webhook.spec.ts
+++ b/tests/mentor-webhook.spec.ts
@@ -68,7 +68,7 @@ test.describe('Mentor webhook endpoint with configured secret', () => {
   });
 
   test('rejects payload missing user_id', async ({ request }) => {
-    const payload = { name: 'No ID Mentor', cf_mentor_title: 'Consultant' };
+    const payload = { name: 'No ID Mentor', cf_mentor_title: 'Consultant',tags: ['role_mentor'] };
     const response = await request.post(WEBHOOK_URL, {
       headers: { 'x-lw-signature': signPayload(payload) },
       data: payload,

--- a/tests/mentor-webhook.spec.ts
+++ b/tests/mentor-webhook.spec.ts
@@ -68,7 +68,7 @@ test.describe('Mentor webhook endpoint with configured secret', () => {
   });
 
   test('rejects payload missing user_id', async ({ request }) => {
-    const payload = { name: 'No ID Mentor', cf_mentor_title: 'Consultant',tags: ['role_mentor'] };
+    const payload = { name: 'No ID Mentor', cf_mentor_title: 'Consultant', tags: ['role_mentor'] };
     const response = await request.post(WEBHOOK_URL, {
       headers: { 'x-lw-signature': signPayload(payload) },
       data: payload,


### PR DESCRIPTION
## Summary

- Updated participant team copy from project description language to an About/team-focused field.
- Moved proposal submission into its own section below the join code.
- Added open-event resubmission support with old submission/AI score cleanup.
- Made AI scoring event-aware and rounded AI scores to 2 decimal places.

## Changes

### Participant Proposal Flow

- Renamed participant-facing team description fields to `About`.
- Changed placeholder copy to `Tell us about your team...`.
- Moved the submit action below the join code into a bordered `Submit Proposal` section.
- Added proposal instructions and due-date guidance.
- Updated submission modal language from project to proposal.

### Resubmission

- Open events now allow teams to resubmit.
- If a team has already submitted during an open event, the CTA turns red and says `Resubmit`.
- Non-open events keep the CTA disabled/greyed out.
- API now rejects direct submission POSTs unless the event status is `open`.
- Resubmission deletes the previous AI score and submission before inserting the new submission.

### AI Scoring

- AI scoring now includes event name and description when embedding criteria.
- Stored/returned AI scores are rounded to 2 decimal places.

## Verification

- Ran Prettier on touched frontend/API files.
- Ran Python compile check for AI/backend files.
- `npx tsc --noEmit` still reports existing implicit-any errors in Supabase helper files:
  - `lib/supabase/middleware.ts`
  - `lib/supabase/server.ts`

Closes #197
